### PR TITLE
feat: update issue templates to use 'description' field for clarity

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,5 +1,6 @@
+---
 name: "🐞 Bug Report"
-about: "Report something that isn't working as expected"
+description: "Use this template to report a bug in the raytracer project."
 labels: ["type:bug"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,5 +1,6 @@
+---
 name: "🚀 Feature Request"
-about: "Suggest an idea or enhancement for the raytracer"
+description: "Use this template to request new features or enhancements."
 labels: ["type:feature"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/improvement.yml
+++ b/.github/ISSUE_TEMPLATE/improvement.yml
@@ -1,6 +1,6 @@
 ---
 name: "🔧 Improvement"
-description: "Template for suggesting improvements to existing code or UX"
+description: "Template for suggesting improvements to existing code or UX."
 labels: ["type:improvement"]
 body:
   - type: input

--- a/.github/ISSUE_TEMPLATE/improvement.yml
+++ b/.github/ISSUE_TEMPLATE/improvement.yml
@@ -1,5 +1,6 @@
+---
 name: "🔧 Improvement"
-about: "Refine existing code or UX without adding new features"
+description: "Template for suggesting improvements to existing code or UX"
 labels: ["type:improvement"]
 body:
   - type: input

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,5 +1,6 @@
+---
 name: "🗒️ Task"
-about: "Standalone piece of work (refactor, docs, chores…)"
+description: "Create a task issue for standalone work items."
 labels: ["type:chore"]
 body:
   - type: input


### PR DESCRIPTION
This pull request updates the issue templates in the `.github/ISSUE_TEMPLATE` directory to improve clarity and consistency by replacing the `about` field with a more descriptive `description` field.

Updates to issue templates:

* [`.github/ISSUE_TEMPLATE/bug.yml`](diffhunk://#diff-45b5634e925b86895feee745ec5650893bae0d56e11b379745e506fd9a6b81bdR1-R3): Updated the description to specify that this template is for reporting bugs in the raytracer project.
* [`.github/ISSUE_TEMPLATE/feature_request.yml`](diffhunk://#diff-c6b098646bf32c644234bec14c2675ea2a3d9c2dc2df450a25aa0e7ff02323cdR1-R3): Updated the description to clarify that this template is for requesting new features or enhancements.
* [`.github/ISSUE_TEMPLATE/improvement.yml`](diffhunk://#diff-3dcead75fa82737b49cfb4274ae55678cf7a8d1cf2bfce6abf5ac45cd1f1ab93R1-R3): Updated the description to indicate that it is for suggesting improvements to existing code or UX.
* [`.github/ISSUE_TEMPLATE/task.yml`](diffhunk://#diff-24ddb99d0699247fe21dffe7eeee5babbaed4567feae20ced0f8dfb06b4b3f7fR1-R3): Updated the description to specify that this template is for creating task issues for standalone work items.