### PR TITLE
25 cylinder primitive

### DIFF
--- a/src/core/Matrix.cpp
+++ b/src/core/Matrix.cpp
@@ -204,6 +204,10 @@ Matrix Matrix::createScaling(double x, double y, double z) {
   return result;
 }
 
+Vector3D Matrix::getTranslation() const {
+  return Vector3D(at(0, 3), at(1, 3), at(2, 3));
+}
+
 std::ostream& operator<<(std::ostream& os, const Matrix& matrix) {
   for (int row = 0; row < 4; ++row) {
     os << "| ";

--- a/src/core/Matrix.hpp
+++ b/src/core/Matrix.hpp
@@ -10,6 +10,7 @@
 
 #include <array>
 #include <iostream>
+#include "./Vector3D.hpp" // Add this include
 
 namespace RayTracer {
 
@@ -144,6 +145,12 @@ class Matrix {
    * @return The scaling matrix
    */
   static Matrix createScaling(double x, double y, double z);
+
+  /**
+   * @brief Get the translation components from the matrix
+   * @return A Vector3D representing the translation (x, y, z)
+   */
+  Vector3D getTranslation() const;
 
  private:
   std::array<double, 16> _data;  ///< Matrix data in row-major order

--- a/src/core/Matrix.hpp
+++ b/src/core/Matrix.hpp
@@ -10,7 +10,7 @@
 
 #include <array>
 #include <iostream>
-#include "./Vector3D.hpp"  // Add this include
+#include "./Vector3D.hpp"
 
 namespace RayTracer {
 

--- a/src/core/Matrix.hpp
+++ b/src/core/Matrix.hpp
@@ -10,7 +10,7 @@
 
 #include <array>
 #include <iostream>
-#include "./Vector3D.hpp" // Add this include
+#include "./Vector3D.hpp"  // Add this include
 
 namespace RayTracer {
 

--- a/src/scene/primitives/Cylinder.cpp
+++ b/src/scene/primitives/Cylinder.cpp
@@ -71,6 +71,10 @@ double Cylinder::getHeight() const {
   return _height;
 }
 
+Vector3D Cylinder::getPosition() const {
+  return _transform.getMatrix().getTranslation();
+}
+
 std::optional<Intersection> Cylinder::intersect(const Ray& ray) const {
   Ray localRay = ray.transform(_inverseTransform);
   double t_min_overall = std::numeric_limits<double>::infinity();

--- a/src/scene/primitives/Cylinder.cpp
+++ b/src/scene/primitives/Cylinder.cpp
@@ -1,76 +1,74 @@
 #include "Cylinder.hpp"
-#include "../../../include/IPrimitive.hpp"
-#include "../../core/Vector3D.hpp"
-#include "../../core/Transform.hpp"
 #include <cmath>
 #include <limits>
 #include <stdexcept>
+#include "../../../include/IPrimitive.hpp"
+#include "../../core/Transform.hpp"
+#include "../../core/Vector3D.hpp"
 
 namespace RayTracer {
 
 Cylinder::Cylinder(double radius, double height, const Color& color)
     : _radius(radius), _height(height), _color(color), _transform() {
-    if (radius <= 0) {
-        throw std::invalid_argument("Cylinder radius must be positive");
-    }
-    if (height <= 0) {
-        throw std::invalid_argument("Cylinder height must be positive");
-    }
-    try {
-        _inverseTransform = _transform.inverse();
-    } catch (const std::runtime_error& e) {
-        _inverseTransform = Transform();
-    }
+  if (radius <= 0) {
+    throw std::invalid_argument("Cylinder radius must be positive");
+  }
+  if (height <= 0) {
+    throw std::invalid_argument("Cylinder height must be positive");
+  }
+  try {
+    _inverseTransform = _transform.inverse();
+  } catch (const std::runtime_error& e) {
+    _inverseTransform = Transform();
+  }
 }
 
 void Cylinder::setTransform(const Transform& transform) {
-    _transform = transform;
-    try {
-        _inverseTransform = _transform.inverse();
-    } catch (const std::runtime_error& e) {
-        _inverseTransform = Transform();
-    }
+  _transform = transform;
+  try {
+    _inverseTransform = _transform.inverse();
+  } catch (const std::runtime_error& e) {
+    _inverseTransform = Transform();
+  }
 }
 
 Transform Cylinder::getTransform() const {
-    return _transform;
+  return _transform;
 }
 
 void Cylinder::setColor(const Color& color) {
-    _color = color;
+  _color = color;
 }
 
 Color Cylinder::getColor() const {
-    return _color;
+  return _color;
 }
 
 Vector3D Cylinder::getNormalAt(const Vector3D& point) const {
-    Vector3D localPoint = _transform.inverse().applyToPoint(point);
-    double halfHeight = _height / 2.0;
-    
-    // Check if point is on a cap
-    if (std::abs(localPoint.getY() - halfHeight) < CYLINDER_EPSILON) {
-        return _transform.applyToNormal(Vector3D(0, 1, 0)).normalized();
-    }
-    if (std::abs(localPoint.getY() + halfHeight) < CYLINDER_EPSILON) {
-        return _transform.applyToNormal(Vector3D(0, -1, 0)).normalized();
-    }
-    
-    // Point is on the body
-    Vector3D localNormal(localPoint.getX(), 0, localPoint.getZ());
-    return _transform.applyToNormal(localNormal).normalized();
+  Vector3D localPoint = _transform.inverse().applyToPoint(point);
+  double halfHeight = _height / 2.0;
+
+  if (std::abs(localPoint.getY() - halfHeight) < CYLINDER_EPSILON) {
+    return _transform.applyToNormal(Vector3D(0, 1, 0)).normalized();
+  }
+  if (std::abs(localPoint.getY() + halfHeight) < CYLINDER_EPSILON) {
+    return _transform.applyToNormal(Vector3D(0, -1, 0)).normalized();
+  }
+
+  Vector3D localNormal(localPoint.getX(), 0, localPoint.getZ());
+  return _transform.applyToNormal(localNormal).normalized();
 }
 
 std::shared_ptr<IPrimitive> Cylinder::clone() const {
-    return std::make_shared<Cylinder>(*this);
+  return std::make_shared<Cylinder>(*this);
 }
 
 double Cylinder::getRadius() const {
-    return _radius;
+  return _radius;
 }
 
 double Cylinder::getHeight() const {
-    return _height;
+  return _height;
 }
 
 std::optional<Intersection> Cylinder::intersect(const Ray& ray) const {
@@ -78,34 +76,30 @@ std::optional<Intersection> Cylinder::intersect(const Ray& ray) const {
   double t_min_overall = std::numeric_limits<double>::infinity();
   std::optional<Intersection> closest_intersection = std::nullopt;
 
-  // Intersect with body
   auto body_intersect_result = intersectBody(localRay, t_min_overall);
   if (body_intersect_result) {
     closest_intersection = body_intersect_result;
-    // t_min_overall is updated within intersectBody if a closer hit is found
   }
 
-  // Intersect with caps
   auto cap_intersect_result = intersectCaps(localRay, t_min_overall);
   if (cap_intersect_result) {
     closest_intersection = cap_intersect_result;
-    // t_min_overall is updated within intersectCaps if a closer hit is found
   }
 
   if (closest_intersection) {
-    // Transform intersection point and normal back to world space
-    Vector3D worldIntersectionPoint = _transform.applyToPoint(closest_intersection->point);
-    Vector3D worldNormal = _transform.applyToNormal(closest_intersection->normal).normalized();
+    Vector3D worldIntersectionPoint =
+        _transform.applyToPoint(closest_intersection->point);
+    Vector3D worldNormal =
+        _transform.applyToNormal(closest_intersection->normal).normalized();
 
-    // Ensure normal points towards the ray origin (away from the surface)
     if (worldNormal.dot(ray.getDirection()) > 0) {
-        worldNormal = -worldNormal;
+      worldNormal = -worldNormal;
     }
 
     closest_intersection->point = worldIntersectionPoint;
     closest_intersection->normal = worldNormal;
-    // Recalculate distance in world space to be accurate
-    closest_intersection->distance = (worldIntersectionPoint - ray.getOrigin()).getMagnitude();
+    closest_intersection->distance =
+        (worldIntersectionPoint - ray.getOrigin()).getMagnitude();
     closest_intersection->color = _color;
     closest_intersection->primitive = this;
     return closest_intersection;
@@ -114,112 +108,108 @@ std::optional<Intersection> Cylinder::intersect(const Ray& ray) const {
   return std::nullopt;
 }
 
-std::optional<Intersection> Cylinder::intersectCaps(const Ray& localRay, double& t_min_overall) const {
-    std::optional<Intersection> cap_intersection = std::nullopt;
-    double halfHeight = _height / 2.0;
+std::optional<Intersection> Cylinder::intersectCaps(
+    const Ray& localRay, double& t_min_overall) const {
+  std::optional<Intersection> cap_intersection = std::nullopt;
+  double halfHeight = _height / 2.0;
 
-    // Top cap: plane Y = halfHeight
-    if (std::abs(localRay.getDirection().getY()) > CYLINDER_EPSILON) { // Avoid division by zero if ray parallel to cap plane
-        double t_top = (halfHeight - localRay.getOrigin().getY()) / localRay.getDirection().getY();
-        if (t_top > CYLINDER_EPSILON && t_top < t_min_overall) {
-            Vector3D p_top = localRay.pointAt(t_top);
-            // Check if intersection point is within the radius of the cap
-            if (p_top.getX() * p_top.getX() + p_top.getZ() * p_top.getZ() <= _radius * _radius + CYLINDER_EPSILON) {
-                t_min_overall = t_top;
-                Intersection intersection_data;
-                intersection_data.distance = t_top; // Local distance for now
-                intersection_data.point = p_top;    // Local point
-                intersection_data.normal = Vector3D(0, 1, 0); // Local normal for top cap
-                // Color and primitive will be set by the main intersect method
-                cap_intersection = intersection_data;
-            }
-        }
+  if (std::abs(localRay.getDirection().getY()) > CYLINDER_EPSILON) {
+    double t_top = (halfHeight - localRay.getOrigin().getY()) /
+                   localRay.getDirection().getY();
+    if (t_top > CYLINDER_EPSILON && t_top < t_min_overall) {
+      Vector3D p_top = localRay.pointAt(t_top);
+      if (p_top.getX() * p_top.getX() + p_top.getZ() * p_top.getZ() <=
+          _radius * _radius + CYLINDER_EPSILON) {
+        t_min_overall = t_top;
+        Intersection intersection_data;
+        intersection_data.distance = t_top;
+        intersection_data.point = p_top;
+        intersection_data.normal = Vector3D(0, 1, 0);
+        cap_intersection = intersection_data;
+      }
     }
+  }
 
-    // Bottom cap: plane Y = -halfHeight
-    if (std::abs(localRay.getDirection().getY()) > CYLINDER_EPSILON) { // Avoid division by zero
-        double t_bottom = (-halfHeight - localRay.getOrigin().getY()) / localRay.getDirection().getY();
-        if (t_bottom > CYLINDER_EPSILON && t_bottom < t_min_overall) {
-            Vector3D p_bottom = localRay.pointAt(t_bottom);
-            // Check if intersection point is within the radius of the cap
-            if (p_bottom.getX() * p_bottom.getX() + p_bottom.getZ() * p_bottom.getZ() <= _radius * _radius + CYLINDER_EPSILON) {
-                t_min_overall = t_bottom;
-                Intersection intersection_data;
-                intersection_data.distance = t_bottom; // Local distance
-                intersection_data.point = p_bottom;   // Local point
-                intersection_data.normal = Vector3D(0, -1, 0); // Local normal for bottom cap
-                cap_intersection = intersection_data;
-            }
-        }
+  if (std::abs(localRay.getDirection().getY()) > CYLINDER_EPSILON) {
+    double t_bottom = (-halfHeight - localRay.getOrigin().getY()) /
+                      localRay.getDirection().getY();
+    if (t_bottom > CYLINDER_EPSILON && t_bottom < t_min_overall) {
+      Vector3D p_bottom = localRay.pointAt(t_bottom);
+      if (p_bottom.getX() * p_bottom.getX() +
+              p_bottom.getZ() * p_bottom.getZ() <=
+          _radius * _radius + CYLINDER_EPSILON) {
+        t_min_overall = t_bottom;
+        Intersection intersection_data;
+        intersection_data.distance = t_bottom;
+        intersection_data.point = p_bottom;
+        intersection_data.normal = Vector3D(0, -1, 0);
+        cap_intersection = intersection_data;
+      }
     }
-    return cap_intersection;
+  }
+  return cap_intersection;
 }
 
-std::optional<Intersection> Cylinder::intersectBody(const Ray& localRay, double& t_min_overall) const {
-    Vector3D O = localRay.getOrigin();
-    Vector3D D = localRay.getDirection();
+std::optional<Intersection> Cylinder::intersectBody(
+    const Ray& localRay, double& t_min_overall) const {
+  Vector3D O = localRay.getOrigin();
+  Vector3D D = localRay.getDirection();
 
-    // Cylinder aligned with Y axis: x^2 + z^2 = radius^2
-    // Ray: P(t) = O + tD
-    // (Ox + tDx)^2 + (Oz + tDz)^2 = radius^2
+  // Cylinder aligned with Y axis: x^2 + z^2 = radius^2
+  // Ray: P(t) = O + tD
+  // (Ox + tDx)^2 + (Oz + tDz)^2 = radius^2
 
-    double a = D.getX() * D.getX() + D.getZ() * D.getZ();
-    double b = 2.0 * (O.getX() * D.getX() + O.getZ() * D.getZ());
-    double c = O.getX() * O.getX() + O.getZ() * O.getZ() - _radius * _radius;
+  double a = D.getX() * D.getX() + D.getZ() * D.getZ();
+  double b = 2.0 * (O.getX() * D.getX() + O.getZ() * D.getZ());
+  double c = O.getX() * O.getX() + O.getZ() * O.getZ() - _radius * _radius;
 
-    if (std::abs(a) < CYLINDER_EPSILON) { // Ray is parallel to the Y-axis (cylinder's axis)
-        // Check if it's inside the infinite cylinder body
-        if (c <= 0) { // Ray is inside or on the boundary of the infinite cylinder
-            // This case is complex as it might hit caps or be entirely within.
-            // For now, we assume if it's parallel and inside, it doesn't hit the body sides in a way that this quadratic solves.
-            // Cap intersections will handle cases where it enters/exits through caps.
-            // Or, if the cylinder is infinitely long and ray is inside, it's an infinite number of intersections.
-            // We are looking for the *first* hit on the *finite* cylinder.
-            // This specific condition (parallel and inside) is better handled by cap checks for a finite cylinder.
-        }
-        return std::nullopt; // No intersection with the curved body if parallel
+  if (std::abs(a) < CYLINDER_EPSILON) {
+    if (c <= 0) {
+      return std::nullopt;
     }
+    return std::nullopt;
+  }
 
-    double discriminant = b * b - 4 * a * c;
+  double discriminant = b * b - 4 * a * c;
 
-    if (discriminant < 0) {
-        return std::nullopt; // No real roots, no intersection with infinite cylinder body
+  if (discriminant < 0) {
+    return std::nullopt;
+  }
+
+  double sqrt_discriminant = std::sqrt(discriminant);
+  double t0 = (-b - sqrt_discriminant) / (2 * a);
+  double t1 = (-b + sqrt_discriminant) / (2 * a);
+
+  std::optional<Intersection> body_intersection = std::nullopt;
+  double halfHeight = _height / 2.0;
+
+  if (t0 > CYLINDER_EPSILON && t0 < t_min_overall) {
+    Vector3D p0 = localRay.pointAt(t0);
+    if (p0.getY() >= -halfHeight - CYLINDER_EPSILON &&
+        p0.getY() <= halfHeight + CYLINDER_EPSILON) {
+      t_min_overall = t0;
+      Intersection intersection_data;
+      intersection_data.distance = t0;
+      intersection_data.point = p0;
+      intersection_data.normal = Vector3D(p0.getX(), 0, p0.getZ()).normalized();
+      body_intersection = intersection_data;
     }
+  }
 
-    double sqrt_discriminant = std::sqrt(discriminant);
-    double t0 = (-b - sqrt_discriminant) / (2 * a);
-    double t1 = (-b + sqrt_discriminant) / (2 * a);
-
-    std::optional<Intersection> body_intersection = std::nullopt;
-    double halfHeight = _height / 2.0;
-
-    // Check t0
-    if (t0 > CYLINDER_EPSILON && t0 < t_min_overall) {
-        Vector3D p0 = localRay.pointAt(t0);
-        if (p0.getY() >= -halfHeight - CYLINDER_EPSILON && p0.getY() <= halfHeight + CYLINDER_EPSILON) {
-            t_min_overall = t0;
-            Intersection intersection_data;
-            intersection_data.distance = t0;
-            intersection_data.point = p0;
-            intersection_data.normal = Vector3D(p0.getX(), 0, p0.getZ()).normalized();
-            body_intersection = intersection_data;
-        }
+  if (t1 > CYLINDER_EPSILON && t1 < t_min_overall) {
+    Vector3D p1 = localRay.pointAt(t1);
+    if (p1.getY() >= -halfHeight - CYLINDER_EPSILON &&
+        p1.getY() <= halfHeight + CYLINDER_EPSILON) {
+      t_min_overall = t1;
+      Intersection intersection_data;
+      intersection_data.distance = t1;
+      intersection_data.point = p1;
+      intersection_data.normal = Vector3D(p1.getX(), 0, p1.getZ()).normalized();
+      body_intersection = intersection_data;
     }
+  }
 
-    // Check t1 (it must be greater than t0, but check if it's a closer valid intersection)
-    if (t1 > CYLINDER_EPSILON && t1 < t_min_overall) {
-        Vector3D p1 = localRay.pointAt(t1);
-        if (p1.getY() >= -halfHeight - CYLINDER_EPSILON && p1.getY() <= halfHeight + CYLINDER_EPSILON) {
-            t_min_overall = t1;
-            Intersection intersection_data;
-            intersection_data.distance = t1;
-            intersection_data.point = p1;
-            intersection_data.normal = Vector3D(p1.getX(), 0, p1.getZ()).normalized();
-            body_intersection = intersection_data;
-        }
-    }
-
-    return body_intersection;
+  return body_intersection;
 }
 
-} // namespace RayTracer
+}  // namespace RayTracer

--- a/src/scene/primitives/Cylinder.cpp
+++ b/src/scene/primitives/Cylinder.cpp
@@ -45,7 +45,7 @@ Color Cylinder::getColor() const {
 }
 
 Vector3D Cylinder::getNormalAt(const Vector3D& point) const {
-  Vector3D localPoint = _transform.inverse().applyToPoint(point);
+  Vector3D localPoint = _inverseTransform.applyToPoint(point);
   double halfHeight = _height / 2.0;
 
   if (std::abs(localPoint.getY() - halfHeight) < CYLINDER_EPSILON) {
@@ -112,10 +112,10 @@ std::optional<Intersection> Cylinder::intersectCaps(
     const Ray& localRay, double& t_min_overall) const {
   std::optional<Intersection> cap_intersection = std::nullopt;
   double halfHeight = _height / 2.0;
+  double directionY = localRay.getDirection().getY();
 
-  if (std::abs(localRay.getDirection().getY()) > CYLINDER_EPSILON) {
-    double t_top = (halfHeight - localRay.getOrigin().getY()) /
-                   localRay.getDirection().getY();
+  if (std::abs(directionY) > CYLINDER_EPSILON) {
+    double t_top = (halfHeight - localRay.getOrigin().getY()) / directionY;
     if (t_top > CYLINDER_EPSILON && t_top < t_min_overall) {
       Vector3D p_top = localRay.pointAt(t_top);
       if (p_top.getX() * p_top.getX() + p_top.getZ() * p_top.getZ() <=

--- a/src/scene/primitives/Cylinder.cpp
+++ b/src/scene/primitives/Cylinder.cpp
@@ -1,0 +1,225 @@
+#include "Cylinder.hpp"
+#include "../../../include/IPrimitive.hpp"
+#include "../../core/Vector3D.hpp"
+#include "../../core/Transform.hpp"
+#include <cmath>
+#include <limits>
+#include <stdexcept>
+
+namespace RayTracer {
+
+Cylinder::Cylinder(double radius, double height, const Color& color)
+    : _radius(radius), _height(height), _color(color), _transform() {
+    if (radius <= 0) {
+        throw std::invalid_argument("Cylinder radius must be positive");
+    }
+    if (height <= 0) {
+        throw std::invalid_argument("Cylinder height must be positive");
+    }
+    try {
+        _inverseTransform = _transform.inverse();
+    } catch (const std::runtime_error& e) {
+        _inverseTransform = Transform();
+    }
+}
+
+void Cylinder::setTransform(const Transform& transform) {
+    _transform = transform;
+    try {
+        _inverseTransform = _transform.inverse();
+    } catch (const std::runtime_error& e) {
+        _inverseTransform = Transform();
+    }
+}
+
+Transform Cylinder::getTransform() const {
+    return _transform;
+}
+
+void Cylinder::setColor(const Color& color) {
+    _color = color;
+}
+
+Color Cylinder::getColor() const {
+    return _color;
+}
+
+Vector3D Cylinder::getNormalAt(const Vector3D& point) const {
+    Vector3D localPoint = _transform.inverse().applyToPoint(point);
+    double halfHeight = _height / 2.0;
+    
+    // Check if point is on a cap
+    if (std::abs(localPoint.getY() - halfHeight) < CYLINDER_EPSILON) {
+        return _transform.applyToNormal(Vector3D(0, 1, 0)).normalized();
+    }
+    if (std::abs(localPoint.getY() + halfHeight) < CYLINDER_EPSILON) {
+        return _transform.applyToNormal(Vector3D(0, -1, 0)).normalized();
+    }
+    
+    // Point is on the body
+    Vector3D localNormal(localPoint.getX(), 0, localPoint.getZ());
+    return _transform.applyToNormal(localNormal).normalized();
+}
+
+std::shared_ptr<IPrimitive> Cylinder::clone() const {
+    return std::make_shared<Cylinder>(*this);
+}
+
+double Cylinder::getRadius() const {
+    return _radius;
+}
+
+double Cylinder::getHeight() const {
+    return _height;
+}
+
+std::optional<Intersection> Cylinder::intersect(const Ray& ray) const {
+  Ray localRay = ray.transform(_inverseTransform);
+  double t_min_overall = std::numeric_limits<double>::infinity();
+  std::optional<Intersection> closest_intersection = std::nullopt;
+
+  // Intersect with body
+  auto body_intersect_result = intersectBody(localRay, t_min_overall);
+  if (body_intersect_result) {
+    closest_intersection = body_intersect_result;
+    // t_min_overall is updated within intersectBody if a closer hit is found
+  }
+
+  // Intersect with caps
+  auto cap_intersect_result = intersectCaps(localRay, t_min_overall);
+  if (cap_intersect_result) {
+    closest_intersection = cap_intersect_result;
+    // t_min_overall is updated within intersectCaps if a closer hit is found
+  }
+
+  if (closest_intersection) {
+    // Transform intersection point and normal back to world space
+    Vector3D worldIntersectionPoint = _transform.applyToPoint(closest_intersection->point);
+    Vector3D worldNormal = _transform.applyToNormal(closest_intersection->normal).normalized();
+
+    // Ensure normal points towards the ray origin (away from the surface)
+    if (worldNormal.dot(ray.getDirection()) > 0) {
+        worldNormal = -worldNormal;
+    }
+
+    closest_intersection->point = worldIntersectionPoint;
+    closest_intersection->normal = worldNormal;
+    // Recalculate distance in world space to be accurate
+    closest_intersection->distance = (worldIntersectionPoint - ray.getOrigin()).getMagnitude();
+    closest_intersection->color = _color;
+    closest_intersection->primitive = this;
+    return closest_intersection;
+  }
+
+  return std::nullopt;
+}
+
+std::optional<Intersection> Cylinder::intersectCaps(const Ray& localRay, double& t_min_overall) const {
+    std::optional<Intersection> cap_intersection = std::nullopt;
+    double halfHeight = _height / 2.0;
+
+    // Top cap: plane Y = halfHeight
+    if (std::abs(localRay.getDirection().getY()) > CYLINDER_EPSILON) { // Avoid division by zero if ray parallel to cap plane
+        double t_top = (halfHeight - localRay.getOrigin().getY()) / localRay.getDirection().getY();
+        if (t_top > CYLINDER_EPSILON && t_top < t_min_overall) {
+            Vector3D p_top = localRay.pointAt(t_top);
+            // Check if intersection point is within the radius of the cap
+            if (p_top.getX() * p_top.getX() + p_top.getZ() * p_top.getZ() <= _radius * _radius + CYLINDER_EPSILON) {
+                t_min_overall = t_top;
+                Intersection intersection_data;
+                intersection_data.distance = t_top; // Local distance for now
+                intersection_data.point = p_top;    // Local point
+                intersection_data.normal = Vector3D(0, 1, 0); // Local normal for top cap
+                // Color and primitive will be set by the main intersect method
+                cap_intersection = intersection_data;
+            }
+        }
+    }
+
+    // Bottom cap: plane Y = -halfHeight
+    if (std::abs(localRay.getDirection().getY()) > CYLINDER_EPSILON) { // Avoid division by zero
+        double t_bottom = (-halfHeight - localRay.getOrigin().getY()) / localRay.getDirection().getY();
+        if (t_bottom > CYLINDER_EPSILON && t_bottom < t_min_overall) {
+            Vector3D p_bottom = localRay.pointAt(t_bottom);
+            // Check if intersection point is within the radius of the cap
+            if (p_bottom.getX() * p_bottom.getX() + p_bottom.getZ() * p_bottom.getZ() <= _radius * _radius + CYLINDER_EPSILON) {
+                t_min_overall = t_bottom;
+                Intersection intersection_data;
+                intersection_data.distance = t_bottom; // Local distance
+                intersection_data.point = p_bottom;   // Local point
+                intersection_data.normal = Vector3D(0, -1, 0); // Local normal for bottom cap
+                cap_intersection = intersection_data;
+            }
+        }
+    }
+    return cap_intersection;
+}
+
+std::optional<Intersection> Cylinder::intersectBody(const Ray& localRay, double& t_min_overall) const {
+    Vector3D O = localRay.getOrigin();
+    Vector3D D = localRay.getDirection();
+
+    // Cylinder aligned with Y axis: x^2 + z^2 = radius^2
+    // Ray: P(t) = O + tD
+    // (Ox + tDx)^2 + (Oz + tDz)^2 = radius^2
+
+    double a = D.getX() * D.getX() + D.getZ() * D.getZ();
+    double b = 2.0 * (O.getX() * D.getX() + O.getZ() * D.getZ());
+    double c = O.getX() * O.getX() + O.getZ() * O.getZ() - _radius * _radius;
+
+    if (std::abs(a) < CYLINDER_EPSILON) { // Ray is parallel to the Y-axis (cylinder's axis)
+        // Check if it's inside the infinite cylinder body
+        if (c <= 0) { // Ray is inside or on the boundary of the infinite cylinder
+            // This case is complex as it might hit caps or be entirely within.
+            // For now, we assume if it's parallel and inside, it doesn't hit the body sides in a way that this quadratic solves.
+            // Cap intersections will handle cases where it enters/exits through caps.
+            // Or, if the cylinder is infinitely long and ray is inside, it's an infinite number of intersections.
+            // We are looking for the *first* hit on the *finite* cylinder.
+            // This specific condition (parallel and inside) is better handled by cap checks for a finite cylinder.
+        }
+        return std::nullopt; // No intersection with the curved body if parallel
+    }
+
+    double discriminant = b * b - 4 * a * c;
+
+    if (discriminant < 0) {
+        return std::nullopt; // No real roots, no intersection with infinite cylinder body
+    }
+
+    double sqrt_discriminant = std::sqrt(discriminant);
+    double t0 = (-b - sqrt_discriminant) / (2 * a);
+    double t1 = (-b + sqrt_discriminant) / (2 * a);
+
+    std::optional<Intersection> body_intersection = std::nullopt;
+    double halfHeight = _height / 2.0;
+
+    // Check t0
+    if (t0 > CYLINDER_EPSILON && t0 < t_min_overall) {
+        Vector3D p0 = localRay.pointAt(t0);
+        if (p0.getY() >= -halfHeight - CYLINDER_EPSILON && p0.getY() <= halfHeight + CYLINDER_EPSILON) {
+            t_min_overall = t0;
+            Intersection intersection_data;
+            intersection_data.distance = t0;
+            intersection_data.point = p0;
+            intersection_data.normal = Vector3D(p0.getX(), 0, p0.getZ()).normalized();
+            body_intersection = intersection_data;
+        }
+    }
+
+    // Check t1 (it must be greater than t0, but check if it's a closer valid intersection)
+    if (t1 > CYLINDER_EPSILON && t1 < t_min_overall) {
+        Vector3D p1 = localRay.pointAt(t1);
+        if (p1.getY() >= -halfHeight - CYLINDER_EPSILON && p1.getY() <= halfHeight + CYLINDER_EPSILON) {
+            t_min_overall = t1;
+            Intersection intersection_data;
+            intersection_data.distance = t1;
+            intersection_data.point = p1;
+            intersection_data.normal = Vector3D(p1.getX(), 0, p1.getZ()).normalized();
+            body_intersection = intersection_data;
+        }
+    }
+
+    return body_intersection;
+}
+
+} // namespace RayTracer

--- a/src/scene/primitives/Cylinder.hpp
+++ b/src/scene/primitives/Cylinder.hpp
@@ -1,0 +1,145 @@
+/*
+** EPITECH PROJECT, 2025
+** Raytracer
+** File description:
+** Cylinder primitive class header
+*/
+
+#ifndef CYLINDER_HPP_
+#define CYLINDER_HPP_
+
+#include <memory>
+#include <optional>
+#include <vector> // Potentially for multiple intersection points, though IPrimitive returns one
+#include "../../../include/IPrimitive.hpp" // Interface
+#include "../../core/Color.hpp"
+#include "../../core/Ray.hpp"
+#include "../../core/Transform.hpp"
+#include "../../core/Vector3D.hpp"
+
+namespace RayTracer {
+
+// Epsilon for floating point comparisons specific to Cylinder
+constexpr double CYLINDER_EPSILON = 1e-6;
+
+/**
+ * @brief Represents a cylinder primitive.
+ * This cylinder is defined by its radius and height.
+ * It is aligned with the Y-axis in its local coordinate system,
+ * centered at (0,0,0), extending from -height/2 to +height/2 on the Y-axis.
+ */
+class Cylinder : public IPrimitive {
+ public:
+  /**
+   * @brief Constructor for a cylinder.
+   * @param radius The radius of the cylinder. Must be positive.
+   * @param height The total height of the cylinder. Must be positive.
+   * @param color The color of the cylinder.
+   */
+  Cylinder(double radius, double height, const Color& color);
+
+  /**
+   * @brief Destructor.
+   */
+  ~Cylinder() override = default;
+
+  // --- IPrimitive Interface Implementation ---
+
+  /**
+   * @brief Check if a ray intersects this cylinder.
+   * Considers intersections with the body and the end caps.
+   * @param ray The ray to check for intersection.
+   * @return An std::optional<Intersection> containing intersection data if a hit
+   * occurs within the cylinder's bounds, std::nullopt otherwise.
+   */
+  std::optional<Intersection> intersect(const Ray& ray) const override;
+
+  /**
+   * @brief Set the transformation matrix for this cylinder.
+   * @param transform The transformation to apply.
+   */
+  void setTransform(const Transform& transform) override;
+
+  /**
+   * @brief Get the transformation of this cylinder.
+   * @return The current transformation.
+   */
+  Transform getTransform() const override;
+
+  /**
+   * @brief Set the color of this cylinder.
+   * @param color The color to set.
+   */
+  void setColor(const Color& color) override;
+
+  /**
+   * @brief Get the color of this cylinder.
+   * @return The current color.
+   */
+  Color getColor() const override;
+
+  /**
+   * @brief Get the normal vector at a specific point on the cylinder's surface.
+   * The point is assumed to be on the surface.
+   * @param point The point in world space.
+   * @return The normal vector at that point.
+   */
+  Vector3D getNormalAt(const Vector3D& point) const override;
+
+  /**
+   * @brief Clone this cylinder.
+   * @return A std::shared_ptr to a new instance of this cylinder with the same properties.
+   */
+  std::shared_ptr<IPrimitive> clone() const override;
+
+  // --- Cylinder Specific Methods ---
+
+  /**
+   * @brief Get the radius of the cylinder.
+   * @return The radius.
+   */
+  double getRadius() const;
+
+  /**
+   * @brief Get the height of the cylinder.
+   * @return The height.
+   */
+  double getHeight() const;
+
+  // Note: Setters for radius and height could be added if dynamic resizing is needed.
+  // For now, they are set at construction.
+
+ private:
+  double _radius;          ///< The radius of the cylinder.
+  double _height;          ///< The total height of the cylinder.
+  Color _color;            ///< The color of the cylinder.
+  Transform _transform;      ///< Transformation applied to the cylinder.
+  Transform _inverseTransform; ///< Cached inverse of _transform for intersection calculations.
+
+  // Helper methods for intersection logic (implemented in Cylinder.cpp)
+  // These methods operate in the cylinder's local coordinate space.
+
+  /**
+   * @brief Calculates intersection with the cylinder's circular end caps.
+   * @param localRay Ray in the cylinder's local coordinate system.
+   * @param t_min_overall Reference to the closest intersection distance found so far.
+   *                      This method will update it if a closer cap intersection is found.
+   * @return An optional Intersection data if a valid cap intersection is found closer
+   *         than t_min_overall, otherwise std::nullopt. Intersection data is in local space.
+   */
+  std::optional<Intersection> intersectCaps(const Ray& localRay, double& t_min_overall) const;
+
+  /**
+   * @brief Calculates intersection with the cylinder's curved body.
+   * @param localRay Ray in the cylinder's local coordinate system.
+   * @param t_min_overall Reference to the closest intersection distance found so far.
+   *                      This method will update it if a closer body intersection is found.
+   * @return An optional Intersection data if a valid body intersection is found closer
+   *         than t_min_overall, otherwise std::nullopt. Intersection data is in local space.
+   */
+  std::optional<Intersection> intersectBody(const Ray& localRay, double& t_min_overall) const;
+};
+
+}  // namespace RayTracer
+
+#endif /* !CYLINDER_HPP_ */

--- a/src/scene/primitives/Cylinder.hpp
+++ b/src/scene/primitives/Cylinder.hpp
@@ -10,8 +10,8 @@
 
 #include <memory>
 #include <optional>
-#include <vector> // Potentially for multiple intersection points, though IPrimitive returns one
-#include "../../../include/IPrimitive.hpp" // Interface
+#include <vector>  // Potentially for multiple intersection points, though IPrimitive returns one
+#include "../../../include/IPrimitive.hpp"  // Interface
 #include "../../core/Color.hpp"
 #include "../../core/Ray.hpp"
 #include "../../core/Transform.hpp"
@@ -49,8 +49,8 @@ class Cylinder : public IPrimitive {
    * @brief Check if a ray intersects this cylinder.
    * Considers intersections with the body and the end caps.
    * @param ray The ray to check for intersection.
-   * @return An std::optional<Intersection> containing intersection data if a hit
-   * occurs within the cylinder's bounds, std::nullopt otherwise.
+   * @return An std::optional<Intersection> containing intersection data if a
+   * hit occurs within the cylinder's bounds, std::nullopt otherwise.
    */
   std::optional<Intersection> intersect(const Ray& ray) const override;
 
@@ -88,7 +88,8 @@ class Cylinder : public IPrimitive {
 
   /**
    * @brief Clone this cylinder.
-   * @return A std::shared_ptr to a new instance of this cylinder with the same properties.
+   * @return A std::shared_ptr to a new instance of this cylinder with the same
+   * properties.
    */
   std::shared_ptr<IPrimitive> clone() const override;
 
@@ -106,15 +107,16 @@ class Cylinder : public IPrimitive {
    */
   double getHeight() const;
 
-  // Note: Setters for radius and height could be added if dynamic resizing is needed.
-  // For now, they are set at construction.
+  // Note: Setters for radius and height could be added if dynamic resizing is
+  // needed. For now, they are set at construction.
 
  private:
-  double _radius;          ///< The radius of the cylinder.
-  double _height;          ///< The total height of the cylinder.
-  Color _color;            ///< The color of the cylinder.
-  Transform _transform;      ///< Transformation applied to the cylinder.
-  Transform _inverseTransform; ///< Cached inverse of _transform for intersection calculations.
+  double _radius;               ///< The radius of the cylinder.
+  double _height;               ///< The total height of the cylinder.
+  Color _color;                 ///< The color of the cylinder.
+  Transform _transform;         ///< Transformation applied to the cylinder.
+  Transform _inverseTransform;  ///< Cached inverse of _transform for
+                                ///< intersection calculations.
 
   // Helper methods for intersection logic (implemented in Cylinder.cpp)
   // These methods operate in the cylinder's local coordinate space.
@@ -122,22 +124,26 @@ class Cylinder : public IPrimitive {
   /**
    * @brief Calculates intersection with the cylinder's circular end caps.
    * @param localRay Ray in the cylinder's local coordinate system.
-   * @param t_min_overall Reference to the closest intersection distance found so far.
-   *                      This method will update it if a closer cap intersection is found.
-   * @return An optional Intersection data if a valid cap intersection is found closer
-   *         than t_min_overall, otherwise std::nullopt. Intersection data is in local space.
+   * @param t_min_overall Reference to the closest intersection distance found
+   * so far. This method will update it if a closer cap intersection is found.
+   * @return An optional Intersection data if a valid cap intersection is found
+   * closer than t_min_overall, otherwise std::nullopt. Intersection data is in
+   * local space.
    */
-  std::optional<Intersection> intersectCaps(const Ray& localRay, double& t_min_overall) const;
+  std::optional<Intersection> intersectCaps(const Ray& localRay,
+                                            double& t_min_overall) const;
 
   /**
    * @brief Calculates intersection with the cylinder's curved body.
    * @param localRay Ray in the cylinder's local coordinate system.
-   * @param t_min_overall Reference to the closest intersection distance found so far.
-   *                      This method will update it if a closer body intersection is found.
-   * @return An optional Intersection data if a valid body intersection is found closer
-   *         than t_min_overall, otherwise std::nullopt. Intersection data is in local space.
+   * @param t_min_overall Reference to the closest intersection distance found
+   * so far. This method will update it if a closer body intersection is found.
+   * @return An optional Intersection data if a valid body intersection is found
+   * closer than t_min_overall, otherwise std::nullopt. Intersection data is in
+   * local space.
    */
-  std::optional<Intersection> intersectBody(const Ray& localRay, double& t_min_overall) const;
+  std::optional<Intersection> intersectBody(const Ray& localRay,
+                                            double& t_min_overall) const;
 };
 
 }  // namespace RayTracer

--- a/src/scene/primitives/Cylinder.hpp
+++ b/src/scene/primitives/Cylinder.hpp
@@ -107,6 +107,12 @@ class Cylinder : public IPrimitive {
    */
   double getHeight() const;
 
+  /**
+   * @brief Get the position of the cylinder
+   * @return The position (translation component) of the cylinder
+   */
+  Vector3D getPosition() const;
+
  private:
   double _radius;               ///< The radius of the cylinder.
   double _height;               ///< The total height of the cylinder.

--- a/src/scene/primitives/Cylinder.hpp
+++ b/src/scene/primitives/Cylinder.hpp
@@ -10,8 +10,8 @@
 
 #include <memory>
 #include <optional>
-#include <vector>  // Potentially for multiple intersection points, though IPrimitive returns one
-#include "../../../include/IPrimitive.hpp"  // Interface
+#include <vector>
+#include "../../../include/IPrimitive.hpp"
 #include "../../core/Color.hpp"
 #include "../../core/Ray.hpp"
 #include "../../core/Transform.hpp"
@@ -107,9 +107,6 @@ class Cylinder : public IPrimitive {
    */
   double getHeight() const;
 
-  // Note: Setters for radius and height could be added if dynamic resizing is
-  // needed. For now, they are set at construction.
-
  private:
   double _radius;               ///< The radius of the cylinder.
   double _height;               ///< The total height of the cylinder.
@@ -118,8 +115,21 @@ class Cylinder : public IPrimitive {
   Transform _inverseTransform;  ///< Cached inverse of _transform for
                                 ///< intersection calculations.
 
-  // Helper methods for intersection logic (implemented in Cylinder.cpp)
-  // These methods operate in the cylinder's local coordinate space.
+  /**
+   * @brief Helper function to check intersection with a single cylinder cap.
+   * @param localRay Ray in the cylinder's local coordinate system.
+   * @param t_min_overall Reference to the closest intersection distance found
+   * so far. Updated if a closer hit is found.
+   * @param cap_y_position The Y coordinate of the cap plane.
+   * @param cap_normal The normal vector of the cap plane (in local space).
+   * @return An optional Intersection data if a valid cap intersection is found
+   * closer than t_min_overall, otherwise std::nullopt. Intersection data is in
+   * local space.
+   */
+  std::optional<Intersection> checkCap(const Ray& localRay,
+                                       double& t_min_overall,
+                                       double cap_y_position,
+                                       const Vector3D& cap_normal) const;
 
   /**
    * @brief Calculates intersection with the cylinder's circular end caps.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ set(TEST_SOURCES
     test_Transform.cpp
     test_Vector3D.cpp
     test_Plane.cpp
+    test_Cylinder.cpp
 )
 
 # Test executable

--- a/tests/test_Cylinder.cpp
+++ b/tests/test_Cylinder.cpp
@@ -30,8 +30,10 @@ using namespace RayTracer;
     std::stringstream ss;
     ss << std::fixed << std::setprecision(9) << "Vectors " << v1_expr << " and "
        << v2_expr << " are not nearly equal (within " << epsilon_expr << ").\n"
-       << v1_expr << ": (" << v1.getX() << ", " << v1.getY() << ", " << v1.getZ() << ")\n"
-       << v2_expr << ": (" << v2.getX() << ", " << v2.getY() << ", " << v2.getZ() << ")\n"
+       << v1_expr << ": (" << v1.getX() << ", " << v1.getY() << ", "
+       << v1.getZ() << ")\n"
+       << v2_expr << ": (" << v2.getX() << ", " << v2.getY() << ", "
+       << v2.getZ() << ")\n"
        << "Difference: (" << dx << ", " << dy << ", " << dz << ")\n"
        << "Epsilon: " << epsilon;
     return ::testing::AssertionFailure() << ss.str();
@@ -41,136 +43,165 @@ using namespace RayTracer;
   EXPECT_PRED_FORMAT3(AssertVectorsNearlyEqualCylinderTest, v1, v2, epsilon)
 
 TEST(CylinderTest, ConstructorValid) {
-    Cylinder cyl(1.0, 2.0, Color::RED);
-    EXPECT_EQ(cyl.getRadius(), 1.0);
-    EXPECT_EQ(cyl.getHeight(), 2.0);
-    EXPECT_EQ(cyl.getColor(), Color::RED);
+  Cylinder cyl(1.0, 2.0, Color::RED);
+  EXPECT_EQ(cyl.getRadius(), 1.0);
+  EXPECT_EQ(cyl.getHeight(), 2.0);
+  EXPECT_EQ(cyl.getColor(), Color::RED);
 }
 
 TEST(CylinderTest, ConstructorInvalidRadius) {
-    EXPECT_THROW(Cylinder(0.0, 2.0, Color::RED), std::invalid_argument);
-    EXPECT_THROW(Cylinder(-1.0, 2.0, Color::RED), std::invalid_argument);
+  EXPECT_THROW(Cylinder(0.0, 2.0, Color::RED), std::invalid_argument);
+  EXPECT_THROW(Cylinder(-1.0, 2.0, Color::RED), std::invalid_argument);
 }
 
 TEST(CylinderTest, ConstructorInvalidHeight) {
-    EXPECT_THROW(Cylinder(1.0, 0.0, Color::RED), std::invalid_argument);
-    EXPECT_THROW(Cylinder(1.0, -2.0, Color::RED), std::invalid_argument);
+  EXPECT_THROW(Cylinder(1.0, 0.0, Color::RED), std::invalid_argument);
+  EXPECT_THROW(Cylinder(1.0, -2.0, Color::RED), std::invalid_argument);
 }
 
 TEST(CylinderTest, RayIntersectionMiss) {
-    Cylinder cyl(1.0, 2.0, Color::BLUE);
-    Ray ray(Vector3D(0, 0, -5), Vector3D(0, 1, 0)); // Ray parallel to Y, outside cylinder body
-    auto intersection = cyl.intersect(ray);
-    EXPECT_FALSE(intersection.has_value());
+  Cylinder cyl(1.0, 2.0, Color::BLUE);
+  Ray ray(Vector3D(0, 0, -5),
+          Vector3D(0, 1, 0));  // Ray parallel to Y, outside cylinder body
+  auto intersection = cyl.intersect(ray);
+  EXPECT_FALSE(intersection.has_value());
 
-    Ray ray2(Vector3D(5, 0, 0), Vector3D(0, 0, 1)); // Ray along Z, outside cylinder body
-    auto intersection2 = cyl.intersect(ray2);
-    EXPECT_FALSE(intersection2.has_value());
+  Ray ray2(Vector3D(5, 0, 0),
+           Vector3D(0, 0, 1));  // Ray along Z, outside cylinder body
+  auto intersection2 = cyl.intersect(ray2);
+  EXPECT_FALSE(intersection2.has_value());
 }
 
 TEST(CylinderTest, RayIntersectionBody) {
-    Cylinder cyl(1.0, 2.0, Color::GREEN); // Centered at origin, radius 1, height 2 (-1 to 1 on Y)
-    Ray ray(Vector3D(0, 0, -5), Vector3D(0, 0, 1)); // Ray along +Z, hits body
+  Cylinder cyl(
+      1.0, 2.0,
+      Color::GREEN);  // Centered at origin, radius 1, height 2 (-1 to 1 on Y)
+  Ray ray(Vector3D(0, 0, -5), Vector3D(0, 0, 1));  // Ray along +Z, hits body
 
-    auto intersection = cyl.intersect(ray);
-    ASSERT_TRUE(intersection.has_value());
-    EXPECT_NEAR(intersection->distance, 4.0, CYLINDER_EPSILON); // Hits at z=-1
-    EXPECT_VECTORS_NEARLY_EQUAL_CYLINDER(intersection->point, Vector3D(0, 0, -1), CYLINDER_EPSILON);
-    // Normal should point towards ray origin (-Z direction)
-    EXPECT_VECTORS_NEARLY_EQUAL_CYLINDER(intersection->normal, Vector3D(0, 0, -1), CYLINDER_EPSILON);
-    EXPECT_EQ(intersection->color, Color::GREEN);
+  auto intersection = cyl.intersect(ray);
+  ASSERT_TRUE(intersection.has_value());
+  EXPECT_NEAR(intersection->distance, 4.0, CYLINDER_EPSILON);  // Hits at z=-1
+  EXPECT_VECTORS_NEARLY_EQUAL_CYLINDER(intersection->point, Vector3D(0, 0, -1),
+                                       CYLINDER_EPSILON);
+  // Normal should point towards ray origin (-Z direction)
+  EXPECT_VECTORS_NEARLY_EQUAL_CYLINDER(intersection->normal, Vector3D(0, 0, -1),
+                                       CYLINDER_EPSILON);
+  EXPECT_EQ(intersection->color, Color::GREEN);
 }
 
 TEST(CylinderTest, RayIntersectionTopCap) {
-    Cylinder cyl(1.0, 2.0, Color::RED); // Height from -1 to 1 on Y
-    Ray ray(Vector3D(0, 5, 0), Vector3D(0, -1, 0)); // Ray along -Y, hits top cap
+  Cylinder cyl(1.0, 2.0, Color::RED);              // Height from -1 to 1 on Y
+  Ray ray(Vector3D(0, 5, 0), Vector3D(0, -1, 0));  // Ray along -Y, hits top cap
 
-    auto intersection = cyl.intersect(ray);
-    ASSERT_TRUE(intersection.has_value());
-    EXPECT_NEAR(intersection->distance, 4.0, CYLINDER_EPSILON); // Hits at y=1
-    EXPECT_VECTORS_NEARLY_EQUAL_CYLINDER(intersection->point, Vector3D(0, 1, 0), CYLINDER_EPSILON);
-    // Normal should point towards ray origin (+Y direction)
-    EXPECT_VECTORS_NEARLY_EQUAL_CYLINDER(intersection->normal, Vector3D(0, 1, 0), CYLINDER_EPSILON);
+  auto intersection = cyl.intersect(ray);
+  ASSERT_TRUE(intersection.has_value());
+  EXPECT_NEAR(intersection->distance, 4.0, CYLINDER_EPSILON);  // Hits at y=1
+  EXPECT_VECTORS_NEARLY_EQUAL_CYLINDER(intersection->point, Vector3D(0, 1, 0),
+                                       CYLINDER_EPSILON);
+  // Normal should point towards ray origin (+Y direction)
+  EXPECT_VECTORS_NEARLY_EQUAL_CYLINDER(intersection->normal, Vector3D(0, 1, 0),
+                                       CYLINDER_EPSILON);
 }
 
 TEST(CylinderTest, RayIntersectionBottomCap) {
-    Cylinder cyl(1.0, 2.0, Color::BLUE);
-    Ray ray(Vector3D(0.5, -5, 0.5), Vector3D(0, 1, 0)); // Ray along +Y, hits bottom cap
+  Cylinder cyl(1.0, 2.0, Color::BLUE);
+  Ray ray(Vector3D(0.5, -5, 0.5),
+          Vector3D(0, 1, 0));  // Ray along +Y, hits bottom cap
 
-    auto intersection = cyl.intersect(ray);
-    ASSERT_TRUE(intersection.has_value());
-    EXPECT_NEAR(intersection->distance, 4.0, CYLINDER_EPSILON); // Hits at y=-1
-    EXPECT_VECTORS_NEARLY_EQUAL_CYLINDER(intersection->point, Vector3D(0.5, -1, 0.5), CYLINDER_EPSILON);
-    // Normal should point towards ray origin (-Y direction)
-    EXPECT_VECTORS_NEARLY_EQUAL_CYLINDER(intersection->normal, Vector3D(0, -1, 0), CYLINDER_EPSILON);
+  auto intersection = cyl.intersect(ray);
+  ASSERT_TRUE(intersection.has_value());
+  EXPECT_NEAR(intersection->distance, 4.0, CYLINDER_EPSILON);  // Hits at y=-1
+  EXPECT_VECTORS_NEARLY_EQUAL_CYLINDER(
+      intersection->point, Vector3D(0.5, -1, 0.5), CYLINDER_EPSILON);
+  // Normal should point towards ray origin (-Y direction)
+  EXPECT_VECTORS_NEARLY_EQUAL_CYLINDER(intersection->normal, Vector3D(0, -1, 0),
+                                       CYLINDER_EPSILON);
 }
 
 TEST(CylinderTest, RayParallelInsideNoHitBody) {
-    Cylinder cyl(1.0, 2.0, Color::YELLOW);
-    // Ray parallel to Y-axis, starting inside the cylinder's radius, pointing upwards
-    Ray ray(Vector3D(0.5, -5, 0), Vector3D(0, 1, 0)); 
-    auto intersection = cyl.intersect(ray);
-    // Should hit the bottom cap first
-    ASSERT_TRUE(intersection.has_value());
-    EXPECT_NEAR(intersection->distance, 4.0, CYLINDER_EPSILON); // Hits bottom cap at y=-1
-    EXPECT_VECTORS_NEARLY_EQUAL_CYLINDER(intersection->point, Vector3D(0.5, -1.0, 0), CYLINDER_EPSILON);
-    EXPECT_VECTORS_NEARLY_EQUAL_CYLINDER(intersection->normal, Vector3D(0, -1, 0), CYLINDER_EPSILON);
+  Cylinder cyl(1.0, 2.0, Color::YELLOW);
+  // Ray parallel to Y-axis, starting inside the cylinder's radius, pointing
+  // upwards
+  Ray ray(Vector3D(0.5, -5, 0), Vector3D(0, 1, 0));
+  auto intersection = cyl.intersect(ray);
+  // Should hit the bottom cap first
+  ASSERT_TRUE(intersection.has_value());
+  EXPECT_NEAR(intersection->distance, 4.0,
+              CYLINDER_EPSILON);  // Hits bottom cap at y=-1
+  EXPECT_VECTORS_NEARLY_EQUAL_CYLINDER(
+      intersection->point, Vector3D(0.5, -1.0, 0), CYLINDER_EPSILON);
+  EXPECT_VECTORS_NEARLY_EQUAL_CYLINDER(intersection->normal, Vector3D(0, -1, 0),
+                                       CYLINDER_EPSILON);
 }
 
 TEST(CylinderTest, RayGrazingEdgeShouldHitCap) {
-    Cylinder cyl(1.0, 2.0, Color::CYAN);
-    // Ray grazes the top edge, should hit the cap, not the body at y=1
-    Ray ray(Vector3D(1.0 - CYLINDER_EPSILON, 5.0, 0.0), Vector3D(0, -1, 0));
-    auto intersection = cyl.intersect(ray);
-    ASSERT_TRUE(intersection.has_value());
-    EXPECT_NEAR(intersection->point.getY(), 1.0, CYLINDER_EPSILON);
-    EXPECT_VECTORS_NEARLY_EQUAL_CYLINDER(intersection->normal, Vector3D(0,1,0), CYLINDER_EPSILON);
+  Cylinder cyl(1.0, 2.0, Color::CYAN);
+  // Ray grazes the top edge, should hit the cap, not the body at y=1
+  Ray ray(Vector3D(1.0 - CYLINDER_EPSILON, 5.0, 0.0), Vector3D(0, -1, 0));
+  auto intersection = cyl.intersect(ray);
+  ASSERT_TRUE(intersection.has_value());
+  EXPECT_NEAR(intersection->point.getY(), 1.0, CYLINDER_EPSILON);
+  EXPECT_VECTORS_NEARLY_EQUAL_CYLINDER(intersection->normal, Vector3D(0, 1, 0),
+                                       CYLINDER_EPSILON);
 }
 
 TEST(CylinderTest, GetNormalAt) {
-    Cylinder cyl(1.0, 2.0, Color::WHITE);
-    // Point on top cap
-    EXPECT_VECTORS_NEARLY_EQUAL_CYLINDER(cyl.getNormalAt(Vector3D(0, 1, 0)), Vector3D(0, 1, 0), CYLINDER_EPSILON);
-    EXPECT_VECTORS_NEARLY_EQUAL_CYLINDER(cyl.getNormalAt(Vector3D(0.5, 1, 0.5)), Vector3D(0, 1, 0), CYLINDER_EPSILON);
-    // Point on bottom cap
-    EXPECT_VECTORS_NEARLY_EQUAL_CYLINDER(cyl.getNormalAt(Vector3D(0, -1, 0)), Vector3D(0, -1, 0), CYLINDER_EPSILON);
-    // Point on body
-    EXPECT_VECTORS_NEARLY_EQUAL_CYLINDER(cyl.getNormalAt(Vector3D(1, 0, 0)), Vector3D(1, 0, 0), CYLINDER_EPSILON);
-    EXPECT_VECTORS_NEARLY_EQUAL_CYLINDER(cyl.getNormalAt(Vector3D(0, 0.5, -1)), Vector3D(0, 0, -1), CYLINDER_EPSILON);
-    double invSqrt2 = 1.0 / std::sqrt(2.0);
-    EXPECT_VECTORS_NEARLY_EQUAL_CYLINDER(cyl.getNormalAt(Vector3D(invSqrt2, 0.2, invSqrt2)), Vector3D(invSqrt2, 0, invSqrt2), CYLINDER_EPSILON);
+  Cylinder cyl(1.0, 2.0, Color::WHITE);
+  // Point on top cap
+  EXPECT_VECTORS_NEARLY_EQUAL_CYLINDER(cyl.getNormalAt(Vector3D(0, 1, 0)),
+                                       Vector3D(0, 1, 0), CYLINDER_EPSILON);
+  EXPECT_VECTORS_NEARLY_EQUAL_CYLINDER(cyl.getNormalAt(Vector3D(0.5, 1, 0.5)),
+                                       Vector3D(0, 1, 0), CYLINDER_EPSILON);
+  // Point on bottom cap
+  EXPECT_VECTORS_NEARLY_EQUAL_CYLINDER(cyl.getNormalAt(Vector3D(0, -1, 0)),
+                                       Vector3D(0, -1, 0), CYLINDER_EPSILON);
+  // Point on body
+  EXPECT_VECTORS_NEARLY_EQUAL_CYLINDER(cyl.getNormalAt(Vector3D(1, 0, 0)),
+                                       Vector3D(1, 0, 0), CYLINDER_EPSILON);
+  EXPECT_VECTORS_NEARLY_EQUAL_CYLINDER(cyl.getNormalAt(Vector3D(0, 0.5, -1)),
+                                       Vector3D(0, 0, -1), CYLINDER_EPSILON);
+  double invSqrt2 = 1.0 / std::sqrt(2.0);
+  EXPECT_VECTORS_NEARLY_EQUAL_CYLINDER(
+      cyl.getNormalAt(Vector3D(invSqrt2, 0.2, invSqrt2)),
+      Vector3D(invSqrt2, 0, invSqrt2), CYLINDER_EPSILON);
 }
 
 TEST(CylinderTest, Clone) {
-    Cylinder original(1.5, 3.0, Color::MAGENTA);
-    Transform t;
-    t.translate(1, 2, 3);
-    t.rotateX(45);
-    original.setTransform(t);
+  Cylinder original(1.5, 3.0, Color::MAGENTA);
+  Transform t;
+  t.translate(1, 2, 3);
+  t.rotateX(45);
+  original.setTransform(t);
 
-    std::shared_ptr<IPrimitive> cloneBase = original.clone();
-    ASSERT_NE(cloneBase, nullptr);
+  std::shared_ptr<IPrimitive> cloneBase = original.clone();
+  ASSERT_NE(cloneBase, nullptr);
 
-    std::shared_ptr<Cylinder> clone = std::dynamic_pointer_cast<Cylinder>(cloneBase);
-    ASSERT_NE(clone, nullptr);
+  std::shared_ptr<Cylinder> clone =
+      std::dynamic_pointer_cast<Cylinder>(cloneBase);
+  ASSERT_NE(clone, nullptr);
 
-    EXPECT_EQ(clone->getRadius(), 1.5);
-    EXPECT_EQ(clone->getHeight(), 3.0);
-    EXPECT_EQ(clone->getColor(), Color::MAGENTA);
-    // EXPECT_EQ(clone->getTransform(), t); // Assuming Transform has operator==
-    // If not, compare matrices or individual components
+  EXPECT_EQ(clone->getRadius(), 1.5);
+  EXPECT_EQ(clone->getHeight(), 3.0);
+  EXPECT_EQ(clone->getColor(), Color::MAGENTA);
+  // EXPECT_EQ(clone->getTransform(), t); // Assuming Transform has operator==
+  // If not, compare matrices or individual components
 
-    // Test intersection with a ray to ensure clone behaves the same
-    Ray ray(Vector3D(1, 0, -5), Vector3D(0, 0, 1));
-    auto originalIntersection = original.intersect(ray);
-    auto cloneIntersection = clone->intersect(ray);
+  // Test intersection with a ray to ensure clone behaves the same
+  Ray ray(Vector3D(1, 0, -5), Vector3D(0, 0, 1));
+  auto originalIntersection = original.intersect(ray);
+  auto cloneIntersection = clone->intersect(ray);
 
-    ASSERT_EQ(originalIntersection.has_value(), cloneIntersection.has_value());
-    if (originalIntersection.has_value()) {
-        EXPECT_NEAR(originalIntersection->distance, cloneIntersection->distance, CYLINDER_EPSILON);
-        EXPECT_VECTORS_NEARLY_EQUAL_CYLINDER(originalIntersection->point, cloneIntersection->point, CYLINDER_EPSILON);
-        EXPECT_VECTORS_NEARLY_EQUAL_CYLINDER(originalIntersection->normal, cloneIntersection->normal, CYLINDER_EPSILON);
-    }
+  ASSERT_EQ(originalIntersection.has_value(), cloneIntersection.has_value());
+  if (originalIntersection.has_value()) {
+    EXPECT_NEAR(originalIntersection->distance, cloneIntersection->distance,
+                CYLINDER_EPSILON);
+    EXPECT_VECTORS_NEARLY_EQUAL_CYLINDER(originalIntersection->point,
+                                         cloneIntersection->point,
+                                         CYLINDER_EPSILON);
+    EXPECT_VECTORS_NEARLY_EQUAL_CYLINDER(originalIntersection->normal,
+                                         cloneIntersection->normal,
+                                         CYLINDER_EPSILON);
+  }
 }
 
 // TODO: Add tests for transformed cylinders

--- a/tests/test_Cylinder.cpp
+++ b/tests/test_Cylinder.cpp
@@ -1,0 +1,178 @@
+/*
+** EPITECH PROJECT, 2025
+** Raytracer
+** File description:
+** Unit tests for Cylinder class
+*/
+
+#include <gtest/gtest.h>
+#include <cmath>
+#include <limits>
+#include "../src/core/Color.hpp"
+#include "../src/core/Ray.hpp"
+#include "../src/core/Transform.hpp"
+#include "../src/core/Vector3D.hpp"
+#include "../src/scene/primitives/Cylinder.hpp"
+
+using namespace RayTracer;
+
+// Helper to compare Vector3D with tolerance (from test_Plane.cpp)
+::testing::AssertionResult AssertVectorsNearlyEqualCylinderTest(
+    const char* v1_expr, const char* v2_expr, const char* epsilon_expr,
+    const Vector3D& v1, const Vector3D& v2, double epsilon) {
+  double dx = std::abs(v1.getX() - v2.getX());
+  double dy = std::abs(v1.getY() - v2.getY());
+  double dz = std::abs(v1.getZ() - v2.getZ());
+  bool pass = dx < epsilon && dy < epsilon && dz < epsilon;
+  if (pass) {
+    return ::testing::AssertionSuccess();
+  } else {
+    std::stringstream ss;
+    ss << std::fixed << std::setprecision(9) << "Vectors " << v1_expr << " and "
+       << v2_expr << " are not nearly equal (within " << epsilon_expr << ").\n"
+       << v1_expr << ": (" << v1.getX() << ", " << v1.getY() << ", " << v1.getZ() << ")\n"
+       << v2_expr << ": (" << v2.getX() << ", " << v2.getY() << ", " << v2.getZ() << ")\n"
+       << "Difference: (" << dx << ", " << dy << ", " << dz << ")\n"
+       << "Epsilon: " << epsilon;
+    return ::testing::AssertionFailure() << ss.str();
+  }
+}
+#define EXPECT_VECTORS_NEARLY_EQUAL_CYLINDER(v1, v2, epsilon) \
+  EXPECT_PRED_FORMAT3(AssertVectorsNearlyEqualCylinderTest, v1, v2, epsilon)
+
+TEST(CylinderTest, ConstructorValid) {
+    Cylinder cyl(1.0, 2.0, Color::RED);
+    EXPECT_EQ(cyl.getRadius(), 1.0);
+    EXPECT_EQ(cyl.getHeight(), 2.0);
+    EXPECT_EQ(cyl.getColor(), Color::RED);
+}
+
+TEST(CylinderTest, ConstructorInvalidRadius) {
+    EXPECT_THROW(Cylinder(0.0, 2.0, Color::RED), std::invalid_argument);
+    EXPECT_THROW(Cylinder(-1.0, 2.0, Color::RED), std::invalid_argument);
+}
+
+TEST(CylinderTest, ConstructorInvalidHeight) {
+    EXPECT_THROW(Cylinder(1.0, 0.0, Color::RED), std::invalid_argument);
+    EXPECT_THROW(Cylinder(1.0, -2.0, Color::RED), std::invalid_argument);
+}
+
+TEST(CylinderTest, RayIntersectionMiss) {
+    Cylinder cyl(1.0, 2.0, Color::BLUE);
+    Ray ray(Vector3D(0, 0, -5), Vector3D(0, 1, 0)); // Ray parallel to Y, outside cylinder body
+    auto intersection = cyl.intersect(ray);
+    EXPECT_FALSE(intersection.has_value());
+
+    Ray ray2(Vector3D(5, 0, 0), Vector3D(0, 0, 1)); // Ray along Z, outside cylinder body
+    auto intersection2 = cyl.intersect(ray2);
+    EXPECT_FALSE(intersection2.has_value());
+}
+
+TEST(CylinderTest, RayIntersectionBody) {
+    Cylinder cyl(1.0, 2.0, Color::GREEN); // Centered at origin, radius 1, height 2 (-1 to 1 on Y)
+    Ray ray(Vector3D(0, 0, -5), Vector3D(0, 0, 1)); // Ray along +Z, hits body
+
+    auto intersection = cyl.intersect(ray);
+    ASSERT_TRUE(intersection.has_value());
+    EXPECT_NEAR(intersection->distance, 4.0, CYLINDER_EPSILON); // Hits at z=-1
+    EXPECT_VECTORS_NEARLY_EQUAL_CYLINDER(intersection->point, Vector3D(0, 0, -1), CYLINDER_EPSILON);
+    // Normal should point towards ray origin (-Z direction)
+    EXPECT_VECTORS_NEARLY_EQUAL_CYLINDER(intersection->normal, Vector3D(0, 0, -1), CYLINDER_EPSILON);
+    EXPECT_EQ(intersection->color, Color::GREEN);
+}
+
+TEST(CylinderTest, RayIntersectionTopCap) {
+    Cylinder cyl(1.0, 2.0, Color::RED); // Height from -1 to 1 on Y
+    Ray ray(Vector3D(0, 5, 0), Vector3D(0, -1, 0)); // Ray along -Y, hits top cap
+
+    auto intersection = cyl.intersect(ray);
+    ASSERT_TRUE(intersection.has_value());
+    EXPECT_NEAR(intersection->distance, 4.0, CYLINDER_EPSILON); // Hits at y=1
+    EXPECT_VECTORS_NEARLY_EQUAL_CYLINDER(intersection->point, Vector3D(0, 1, 0), CYLINDER_EPSILON);
+    // Normal should point towards ray origin (+Y direction)
+    EXPECT_VECTORS_NEARLY_EQUAL_CYLINDER(intersection->normal, Vector3D(0, 1, 0), CYLINDER_EPSILON);
+}
+
+TEST(CylinderTest, RayIntersectionBottomCap) {
+    Cylinder cyl(1.0, 2.0, Color::BLUE);
+    Ray ray(Vector3D(0.5, -5, 0.5), Vector3D(0, 1, 0)); // Ray along +Y, hits bottom cap
+
+    auto intersection = cyl.intersect(ray);
+    ASSERT_TRUE(intersection.has_value());
+    EXPECT_NEAR(intersection->distance, 4.0, CYLINDER_EPSILON); // Hits at y=-1
+    EXPECT_VECTORS_NEARLY_EQUAL_CYLINDER(intersection->point, Vector3D(0.5, -1, 0.5), CYLINDER_EPSILON);
+    // Normal should point towards ray origin (-Y direction)
+    EXPECT_VECTORS_NEARLY_EQUAL_CYLINDER(intersection->normal, Vector3D(0, -1, 0), CYLINDER_EPSILON);
+}
+
+TEST(CylinderTest, RayParallelInsideNoHitBody) {
+    Cylinder cyl(1.0, 2.0, Color::YELLOW);
+    // Ray parallel to Y-axis, starting inside the cylinder's radius, pointing upwards
+    Ray ray(Vector3D(0.5, -5, 0), Vector3D(0, 1, 0)); 
+    auto intersection = cyl.intersect(ray);
+    // Should hit the bottom cap first
+    ASSERT_TRUE(intersection.has_value());
+    EXPECT_NEAR(intersection->distance, 4.0, CYLINDER_EPSILON); // Hits bottom cap at y=-1
+    EXPECT_VECTORS_NEARLY_EQUAL_CYLINDER(intersection->point, Vector3D(0.5, -1.0, 0), CYLINDER_EPSILON);
+    EXPECT_VECTORS_NEARLY_EQUAL_CYLINDER(intersection->normal, Vector3D(0, -1, 0), CYLINDER_EPSILON);
+}
+
+TEST(CylinderTest, RayGrazingEdgeShouldHitCap) {
+    Cylinder cyl(1.0, 2.0, Color::CYAN);
+    // Ray grazes the top edge, should hit the cap, not the body at y=1
+    Ray ray(Vector3D(1.0 - CYLINDER_EPSILON, 5.0, 0.0), Vector3D(0, -1, 0));
+    auto intersection = cyl.intersect(ray);
+    ASSERT_TRUE(intersection.has_value());
+    EXPECT_NEAR(intersection->point.getY(), 1.0, CYLINDER_EPSILON);
+    EXPECT_VECTORS_NEARLY_EQUAL_CYLINDER(intersection->normal, Vector3D(0,1,0), CYLINDER_EPSILON);
+}
+
+TEST(CylinderTest, GetNormalAt) {
+    Cylinder cyl(1.0, 2.0, Color::WHITE);
+    // Point on top cap
+    EXPECT_VECTORS_NEARLY_EQUAL_CYLINDER(cyl.getNormalAt(Vector3D(0, 1, 0)), Vector3D(0, 1, 0), CYLINDER_EPSILON);
+    EXPECT_VECTORS_NEARLY_EQUAL_CYLINDER(cyl.getNormalAt(Vector3D(0.5, 1, 0.5)), Vector3D(0, 1, 0), CYLINDER_EPSILON);
+    // Point on bottom cap
+    EXPECT_VECTORS_NEARLY_EQUAL_CYLINDER(cyl.getNormalAt(Vector3D(0, -1, 0)), Vector3D(0, -1, 0), CYLINDER_EPSILON);
+    // Point on body
+    EXPECT_VECTORS_NEARLY_EQUAL_CYLINDER(cyl.getNormalAt(Vector3D(1, 0, 0)), Vector3D(1, 0, 0), CYLINDER_EPSILON);
+    EXPECT_VECTORS_NEARLY_EQUAL_CYLINDER(cyl.getNormalAt(Vector3D(0, 0.5, -1)), Vector3D(0, 0, -1), CYLINDER_EPSILON);
+    double invSqrt2 = 1.0 / std::sqrt(2.0);
+    EXPECT_VECTORS_NEARLY_EQUAL_CYLINDER(cyl.getNormalAt(Vector3D(invSqrt2, 0.2, invSqrt2)), Vector3D(invSqrt2, 0, invSqrt2), CYLINDER_EPSILON);
+}
+
+TEST(CylinderTest, Clone) {
+    Cylinder original(1.5, 3.0, Color::MAGENTA);
+    Transform t;
+    t.translate(1, 2, 3);
+    t.rotateX(45);
+    original.setTransform(t);
+
+    std::shared_ptr<IPrimitive> cloneBase = original.clone();
+    ASSERT_NE(cloneBase, nullptr);
+
+    std::shared_ptr<Cylinder> clone = std::dynamic_pointer_cast<Cylinder>(cloneBase);
+    ASSERT_NE(clone, nullptr);
+
+    EXPECT_EQ(clone->getRadius(), 1.5);
+    EXPECT_EQ(clone->getHeight(), 3.0);
+    EXPECT_EQ(clone->getColor(), Color::MAGENTA);
+    // EXPECT_EQ(clone->getTransform(), t); // Assuming Transform has operator==
+    // If not, compare matrices or individual components
+
+    // Test intersection with a ray to ensure clone behaves the same
+    Ray ray(Vector3D(1, 0, -5), Vector3D(0, 0, 1));
+    auto originalIntersection = original.intersect(ray);
+    auto cloneIntersection = clone->intersect(ray);
+
+    ASSERT_EQ(originalIntersection.has_value(), cloneIntersection.has_value());
+    if (originalIntersection.has_value()) {
+        EXPECT_NEAR(originalIntersection->distance, cloneIntersection->distance, CYLINDER_EPSILON);
+        EXPECT_VECTORS_NEARLY_EQUAL_CYLINDER(originalIntersection->point, cloneIntersection->point, CYLINDER_EPSILON);
+        EXPECT_VECTORS_NEARLY_EQUAL_CYLINDER(originalIntersection->normal, cloneIntersection->normal, CYLINDER_EPSILON);
+    }
+}
+
+// TODO: Add tests for transformed cylinders
+// TODO: Add tests for rays originating inside the cylinder
+// TODO: Add tests for rays grazing the cylinder edges more thoroughly


### PR DESCRIPTION
This pull request introduces the `Cylinder` primitive to the raytracer, including its implementation, header, and unit tests. The `Cylinder` supports intersection calculations, normal computation, and transformation handling. It also includes comprehensive unit tests to validate the functionality.

### Cylinder Implementation:

* **New class `Cylinder` added**: Implements the `IPrimitive` interface to represent a cylinder with a defined radius, height, and color. It includes methods for ray intersection (`intersect`), normal computation (`getNormalAt`), and transformation handling (`setTransform`, `getTransform`). The cylinder is aligned with the Y-axis and supports intersections with both its body and caps. (`src/scene/primitives/Cylinder.cpp`, `src/scene/primitives/Cylinder.hpp`) [[1]](diffhunk://#diff-b1860312eee6f49223eb0e0dc2ecbbab27e23ddf5b098098fdc270453f64add4R1-R215) [[2]](diffhunk://#diff-0db1e9db7f2bec85e5905c4d51756d97d9d692880df057bbbf67fc70a2b3ed3fR1-R151)

### Test Integration:

* **Unit tests for `Cylinder`**: Added a new test file `test_Cylinder.cpp` with extensive test cases for the `Cylinder` class. Tests cover valid and invalid constructors, ray intersection with the body and caps, normal computation, and the `clone` method. (`tests/test_Cylinder.cpp`)
* **Test list updated**: Included `test_Cylinder.cpp` in the test source list in `CMakeLists.txt`. (`tests/CMakeLists.txt`)