### PR TITLE
feat(Plane): add accessors for axis, position, and normal vector

### DIFF
--- a/src/scene/primitives/Plane.cpp
+++ b/src/scene/primitives/Plane.cpp
@@ -138,4 +138,16 @@ char Plane::getCharFromAxis(Axis axis) const {
   }
 }
 
+double Plane::getPosition() const {
+  return _position;
+}
+
+Vector3D Plane::getNormal() const {
+  return _normal;
+}
+
+Axis Plane::getAxis() const {
+  return _axis;
+}
+
 }  // namespace RayTracer

--- a/src/scene/primitives/Plane.hpp
+++ b/src/scene/primitives/Plane.hpp
@@ -93,19 +93,19 @@ class Plane : public IPrimitive {
    * @brief Get the axis of the plane
    * @return The axis the plane is aligned with
    */
-  Axis getAxis() const { return _axis; }
+  Axis getAxis() const;
 
   /**
    * @brief Get the position of the plane along the axis
    * @return The position of the plane
    */
 
-  double getPosition() const { return _position; }
+  double getPosition() const;
   /**
    * @brief Get the normal vector of the plane
    * @return The normal vector of the plane
    */
-  Vector3D getNormal() const { return _normal; }
+  Vector3D getNormal() const;
 
  private:
   Axis getAxisFromChar(char axis) const;

--- a/src/scene/primitives/Plane.hpp
+++ b/src/scene/primitives/Plane.hpp
@@ -99,8 +99,8 @@ class Plane : public IPrimitive {
    * @brief Get the position of the plane along the axis
    * @return The position of the plane
    */
-
   double getPosition() const;
+
   /**
    * @brief Get the normal vector of the plane
    * @return The normal vector of the plane

--- a/src/scene/primitives/Plane.hpp
+++ b/src/scene/primitives/Plane.hpp
@@ -89,6 +89,24 @@ class Plane : public IPrimitive {
    */
   std::shared_ptr<IPrimitive> clone() const override;
 
+  /**
+   * @brief Get the axis of the plane
+   * @return The axis the plane is aligned with
+   */
+  Axis getAxis() const { return _axis; }
+
+  /**
+   * @brief Get the position of the plane along the axis
+   * @return The position of the plane
+   */
+
+  double getPosition() const { return _position; }
+  /**
+   * @brief Get the normal vector of the plane
+   * @return The normal vector of the plane
+   */
+  Vector3D getNormal() const { return _normal; }
+
  private:
   Axis getAxisFromChar(char axis) const;
   char getCharFromAxis(Axis axis) const;


### PR DESCRIPTION
This pull request introduces new getter methods to the `Plane` class in `src/scene/primitives/Plane.hpp`. These methods provide access to key properties of the plane, enhancing its usability and encapsulation. 

Enhancements to the `Plane` class:

* Added `getAxis()` method to retrieve the axis the plane is aligned with.
* Added `getPosition()` method to retrieve the position of the plane along its axis.
* Added `getNormal()` method to retrieve the normal vector of the plane.