### PR TITLE
Add chessboard plane

### DIFF
--- a/.github/workflows/raytracer_ci.yml
+++ b/.github/workflows/raytracer_ci.yml
@@ -69,7 +69,7 @@ jobs:
     - name: Install dependencies
       run: |
         apt-get update
-        apt-get install -y libconfig++-dev libsfml-dev lcov 
+        apt-get install -y libconfig++-dev libsfml-dev lcov
         # Install a specific version of clang-format (for consistency with local environment)
         apt-get install -y wget gnupg software-properties-common
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -

--- a/scenes/demo_chessboard.cfg
+++ b/scenes/demo_chessboard.cfg
@@ -1,0 +1,46 @@
+# Configuration of the camera
+camera :
+{
+resolution = { width = 1920; height = 1080; };
+position = { x = 0; y = -100; z = 20; };
+rotation = { x = 0; y = 0; z = 0; };
+fieldOfView = 72.0; # In degree
+};
+
+# Primitives in the scene
+primitives :
+{
+  # List of spheres
+  spheres = (
+    { x = 60; y = 5; z = 40; r = 25; color = { r = 255; g = 64; b = 64; }; } ,
+    { x = -40; y = 20; z = -10; r = 35; color = { r = 64; g = 255; b = 64; }; }
+  );
+
+  # Chessboard plane
+  chessboardPlanes = (
+    {
+      axis = "Z";
+      position = -20;
+      color = { r = 240; g = 240; b = 240; };
+      checkerboard = {
+        alternateColor = { r = 40; g = 40; b = 40; };
+        size = 20.0;
+      }
+    }
+  );
+};
+
+# Light configuration
+lights :
+{
+  ambient = 0.4; # Multiplier of ambient light
+  diffuse = 0.6; # Multiplier of diffuse light
+
+  # List of point lights
+  point = (
+    { x = 400; y = 100; z = 500; };
+  );
+
+  # List of directional lights
+  directional = ();
+};

--- a/src/scene/parser/SceneParser.hpp
+++ b/src/scene/parser/SceneParser.hpp
@@ -15,11 +15,18 @@
 #include "../../core/Vector3D.hpp"
 #include "../Camera.hpp"
 #include "../lights/Light.hpp"
+#include "../primitives/ChessboardPlane.hpp"
 #include "../primitives/Cone.hpp"
 #include "../primitives/Plane.hpp"
 #include "../primitives/Sphere.hpp"
 
 namespace RayTracer {
+
+class Camera;
+class Cone;
+class Plane;
+class ChessboardPlane;
+class Light;
 
 class SceneParser {
  public:
@@ -29,6 +36,8 @@ class SceneParser {
   std::vector<Sphere> parseSpheres(const libconfig::Setting& setting);
   Plane parsePlane(const libconfig::Setting& planeSetting);
   std::vector<Plane> parsePlanes(const libconfig::Setting& setting);
+  ChessboardPlane parseChessboardPlane(const libconfig::Setting& planeSetting);
+  std::vector<ChessboardPlane> parseChessboardPlanes(const libconfig::Setting& setting);
   Cone parseCone(const libconfig::Setting& coneSetting);
   std::vector<Cone> parseCones(const libconfig::Setting& setting);
   std::shared_ptr<Light> parseLights(const libconfig::Setting& lightsSetting);

--- a/src/scene/primitives/ChessboardPlane.cpp
+++ b/src/scene/primitives/ChessboardPlane.cpp
@@ -1,0 +1,101 @@
+/*
+** EPITECH PROJECT, 2025
+** Raytracer
+** File description:
+** Chessboard plane primitive implementation
+*/
+
+#include "ChessboardPlane.hpp"
+#include <cmath>
+#include <iostream>
+#include "../../../include/exceptions/RaytracerException.hpp"
+
+namespace RayTracer {
+
+ChessboardPlane::ChessboardPlane(char axis, double position, const Color& color,
+                                 const Color& alternateColor, double checkSize)
+    : Plane(axis, position, color),
+      _alternateColor(alternateColor),
+      _checkSize(checkSize) {
+  if (checkSize <= 0.0) {
+    throw std::invalid_argument("Checkerboard square size must be positive");
+  }
+}
+
+std::optional<Intersection> ChessboardPlane::intersect(const Ray& ray) const {
+  // First get the basic plane intersection
+  auto intersection = Plane::intersect(ray);
+
+  if (!intersection.has_value()) {
+    return std::nullopt;
+  }
+
+  // Transform the intersection point back to local space for pattern calculation
+  Ray localRay = ray.transform(getTransform().inverse());
+  double t = (intersection->distance) / localRay.getDirection().getMagnitude();
+  Vector3D localIntersectionPoint = localRay.pointAt(t);
+
+  // Apply the checkerboard pattern
+  if (isWhiteSquare(localIntersectionPoint)) {
+    intersection->color = getColor();
+  } else {
+    intersection->color = _alternateColor;
+  }
+
+  return intersection;
+}
+
+std::shared_ptr<IPrimitive> ChessboardPlane::clone() const {
+  char axisChar = 'Z';
+  Axis axis = getAxis();
+
+  if (axis == Axis::X) axisChar = 'X';
+  else if (axis == Axis::Y) axisChar = 'Y';
+
+  auto cloned = std::make_shared<ChessboardPlane>(
+      axisChar, getPosition(), getColor(), _alternateColor, _checkSize);
+  cloned->setTransform(getTransform());
+  return cloned;
+}
+
+void ChessboardPlane::setAlternateColor(const Color& color) {
+  _alternateColor = color;
+}
+
+Color ChessboardPlane::getAlternateColor() const {
+  return _alternateColor;
+}
+
+void ChessboardPlane::setCheckSize(double size) {
+  if (size <= 0.0) {
+    throw std::invalid_argument("Checkerboard square size must be positive");
+  }
+  _checkSize = size;
+}
+
+double ChessboardPlane::getCheckSize() const {
+  return _checkSize;
+}
+
+bool ChessboardPlane::isWhiteSquare(const Vector3D& point) const {
+  double u, v;
+  Axis axis = getAxis();
+
+  if (axis == Axis::X) {
+    u = point.getY();
+    v = point.getZ();
+  } else if (axis == Axis::Y) {
+    u = point.getX();
+    v = point.getZ();
+  } else {  // Axis::Z
+    u = point.getX();
+    v = point.getY();
+  }
+
+  int ui = static_cast<int>(std::floor(u / _checkSize));
+  int vi = static_cast<int>(std::floor(v / _checkSize));
+
+  return (ui + vi) % 2 == 0;
+}
+
+}  // namespace RayTracer

--- a/src/scene/primitives/ChessboardPlane.hpp
+++ b/src/scene/primitives/ChessboardPlane.hpp
@@ -1,0 +1,90 @@
+/*
+** EPITECH PROJECT, 2025
+** Raytracer
+** File description:
+** Chessboard plane primitive header
+*/
+
+#ifndef CHESSBOARD_PLANE_HPP_
+#define CHESSBOARD_PLANE_HPP_
+
+#include <memory>
+#include <optional>
+#include "Plane.hpp"
+
+namespace RayTracer {
+
+/**
+ * @brief Represents a plane with a chessboard pattern
+ */
+class ChessboardPlane : public Plane {
+ public:
+  /**
+   * @brief Constructor for a chessboard plane
+   * @param axis The axis the plane is perpendicular to ('X', 'Y', or 'Z')
+   * @param position The position of the plane along the specified axis
+   * @param color The primary color of the chessboard
+   * @param alternateColor The alternate color for checkerboard pattern
+   * @param checkSize The size of each square in the checkerboard pattern
+   */
+  explicit ChessboardPlane(char axis, double position, const Color& color,
+                           const Color& alternateColor = Color::BLACK,
+                           double checkSize = 10.0);
+
+  /**
+   * @brief Destructor
+   */
+  ~ChessboardPlane() override = default;
+
+  /**
+   * @brief Check if a ray intersects this plane
+   * @param ray The ray to check
+   * @return Intersection data if hit, std::nullopt otherwise
+   */
+  std::optional<Intersection> intersect(const Ray& ray) const override;
+
+  /**
+   * @brief Clone this chessboard plane
+   * @return A new instance of this chessboard plane
+   */
+  std::shared_ptr<IPrimitive> clone() const override;
+
+  /**
+   * @brief Set the alternating color for checkerboard pattern
+   * @param color The color to set
+   */
+  void setAlternateColor(const Color& color);
+
+  /**
+   * @brief Get the alternating color for checkerboard pattern
+   * @return The current alternate color
+   */
+  Color getAlternateColor() const;
+
+  /**
+   * @brief Set the size of each square in the checkerboard pattern
+   * @param size The size of each square
+   */
+  void setCheckSize(double size);
+
+  /**
+   * @brief Get the size of each square in the checkerboard pattern
+   * @return The current check size
+   */
+  double getCheckSize() const;
+
+ private:
+  /**
+   * @brief Determine if a point on the plane is on a primary or alternate square
+   * @param point The point to check
+   * @return true if on a primary square, false if on an alternate square
+   */
+  bool isWhiteSquare(const Vector3D& point) const;
+
+  Color _alternateColor;  ///< The alternate color for checkerboard pattern
+  double _checkSize;      ///< Size of each square in the checkerboard pattern
+};
+
+}  // namespace RayTracer
+
+#endif /* !CHESSBOARD_PLANE_HPP_ */

--- a/src/scene/primitives/Plane.cpp
+++ b/src/scene/primitives/Plane.cpp
@@ -12,13 +12,10 @@
 
 namespace RayTracer {
 
-Plane::Plane(char axis, double position, const Color& color,
-             const Color& alternateColor, double checkSize)
+Plane::Plane(char axis, double position, const Color& color)
     : _position(position),
       _color(color),
-      _transform(),
-      _alternateColor(alternateColor),
-      _checkSize(checkSize) {
+      _transform() {
   _axis = getAxisFromChar(axis);
   if (_axis == Axis::X) {
     _normal = Vector3D(1, 0, 0);
@@ -76,13 +73,7 @@ std::optional<Intersection> Plane::intersect(const Ray& ray) const {
       (worldIntersectionPoint - ray.getOrigin()).getMagnitude();
   intersection.point = worldIntersectionPoint;
   intersection.normal = worldNormal;
-
-  if (isWhiteSquare(localIntersectionPoint)) {
-    intersection.color = _color;
-  } else {
-    intersection.color = _alternateColor;
-  }
-
+  intersection.color = _color;
   intersection.primitive = this;
 
   return intersection;
@@ -119,8 +110,7 @@ Vector3D Plane::getNormalAt(const Vector3D& point) const {
 
 std::shared_ptr<IPrimitive> Plane::clone() const {
   char axisEnum = getCharFromAxis(_axis);
-  auto clonedPlane = std::make_shared<Plane>(axisEnum, _position, _color,
-                                             _alternateColor, _checkSize);
+  auto clonedPlane = std::make_shared<Plane>(axisEnum, _position, _color);
   clonedPlane->setTransform(_transform);
   return clonedPlane;
 }
@@ -160,45 +150,6 @@ Vector3D Plane::getNormal() const {
 
 Axis Plane::getAxis() const {
   return _axis;
-}
-
-void Plane::setAlternateColor(const Color& color) {
-  _alternateColor = color;
-}
-
-Color Plane::getAlternateColor() const {
-  return _alternateColor;
-}
-
-void Plane::setCheckSize(double size) {
-  if (size <= 0.0) {
-    throw std::invalid_argument("Checkerboard square size must be positive");
-  }
-  _checkSize = size;
-}
-
-double Plane::getCheckSize() const {
-  return _checkSize;
-}
-
-bool Plane::isWhiteSquare(const Vector3D& point) const {
-  double u, v;
-
-  if (_axis == Axis::X) {
-    u = point.getY();
-    v = point.getZ();
-  } else if (_axis == Axis::Y) {
-    u = point.getX();
-    v = point.getZ();
-  } else {  // Axis::Z
-    u = point.getX();
-    v = point.getY();
-  }
-
-  int ui = static_cast<int>(std::floor(u / _checkSize));
-  int vi = static_cast<int>(std::floor(v / _checkSize));
-
-  return (ui + vi) % 2 == 0;
 }
 
 }  // namespace RayTracer

--- a/src/scene/primitives/Plane.hpp
+++ b/src/scene/primitives/Plane.hpp
@@ -37,14 +37,8 @@ class Plane : public IPrimitive {
    * @param axis The axis the plane is perpendicular to ('X', 'Y', or 'Z')
    * @param position The position of the plane along the specified axis
    * @param color The color of the plane
-   * @param alternateColor The alternate color for checkerboard pattern (default
-   * black)
-   * @param checkSize The size of each square in the checkerboard pattern
-   * (default 10.0)
    */
-  explicit Plane(char axis, double position, const Color& color,
-                 const Color& alternateColor = Color::BLACK,
-                 double checkSize = 10.0);
+  explicit Plane(char axis, double position, const Color& color);
 
   /**
    * @brief Destructor
@@ -113,36 +107,7 @@ class Plane : public IPrimitive {
    */
   Vector3D getNormal() const;
 
-  /**
-   * @brief Set the alternating color for checkerboard pattern
-   * @param color The color to set
-   */
-  void setAlternateColor(const Color& color);
 
-  /**
-   * @brief Get the alternating color for checkerboard pattern
-   * @return The current alternate color
-   */
-  Color getAlternateColor() const;
-
-  /**
-   * @brief Set the size of each square in the checkerboard pattern
-   * @param size The size of each square
-   */
-  void setCheckSize(double size);
-
-  /**
-   * @brief Get the size of each square in the checkerboard pattern
-   * @return The current check size
-   */
-  double getCheckSize() const;
-
-  /**
-   * @brief Determine if a point on the plane is on a black or white square
-   * @param point The point to check
-   * @return true if on a white square, false if on a black square
-   */
-  bool isWhiteSquare(const Vector3D& point) const;
 
  private:
   Axis getAxisFromChar(char axis) const;
@@ -153,8 +118,6 @@ class Plane : public IPrimitive {
   Color _color;          ///< The color of the plane
   Transform _transform;  ///< Transformation applied to the plane
   Transform _inverseTransform;  ///< Inverse transformation
-  Color _alternateColor;  ///< The alternate color for checkerboard pattern
-  double _checkSize;      ///< Size of each square in the checkerboard pattern
 };
 
 }  // namespace RayTracer

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(TEST_SOURCES
     test_Camera.cpp
+    test_ChessboardPlane.cpp
     test_Color.cpp
     test_Ray.cpp
     test_Sphere.cpp

--- a/tests/test_ChessboardPlane.cpp
+++ b/tests/test_ChessboardPlane.cpp
@@ -1,0 +1,117 @@
+/*
+** EPITECH PROJECT, 2025
+** Raytracer
+** File description:
+** Unit tests for ChessboardPlane class
+*/
+
+#include <gtest/gtest.h>
+#include <cmath>
+#include "../src/core/Color.hpp"
+#include "../src/core/Ray.hpp"
+#include "../src/core/Transform.hpp"
+#include "../src/core/Vector3D.hpp"
+#include "../src/scene/primitives/ChessboardPlane.hpp"
+
+using namespace RayTracer;
+
+// Helper function to compare Vector3D with tolerance
+bool vectorsNearlyEqual_ChessboardTest(const Vector3D& v1, const Vector3D& v2,
+                                      double epsilon = 1e-5) {
+  double dx = std::abs(v1.getX() - v2.getX());
+  double dy = std::abs(v1.getY() - v2.getY());
+  double dz = std::abs(v1.getZ() - v2.getZ());
+  return dx < epsilon && dy < epsilon && dz < epsilon;
+}
+
+// Test constructor
+TEST(ChessboardPlaneTest, Constructor) {
+  // Test basic construction
+  ChessboardPlane plane('Z', 0.0, Color::RED, Color::BLACK, 20.0);
+
+  // Test position and normal
+  EXPECT_DOUBLE_EQ(plane.getPosition(), 0.0);
+  EXPECT_TRUE(vectorsNearlyEqual_ChessboardTest(plane.getNormal(), Vector3D(0, 0, 1)));
+
+  // Test colors
+  EXPECT_EQ(plane.getColor(), Color::RED);
+  EXPECT_EQ(plane.getAlternateColor(), Color::BLACK);
+
+  // Test check size
+  EXPECT_DOUBLE_EQ(plane.getCheckSize(), 20.0);
+}
+
+// Test intersection with chessboard pattern
+TEST(ChessboardPlaneTest, ChessboardPattern) {
+  ChessboardPlane plane('Z', 0.0, Color::WHITE, Color::BLACK, 10.0);
+
+  // Point at (5, 5, 0) should be on a white square (primary color)
+  Ray ray1(Vector3D(5, 5, -5), Vector3D(0, 0, 1));
+  auto intersection1 = plane.intersect(ray1);
+  ASSERT_TRUE(intersection1.has_value());
+  EXPECT_EQ(intersection1->color, Color::WHITE);
+
+  // Point at (15, 5, 0) should be on a black square (alternate color)
+  Ray ray2(Vector3D(15, 5, -5), Vector3D(0, 0, 1));
+  auto intersection2 = plane.intersect(ray2);
+  ASSERT_TRUE(intersection2.has_value());
+  EXPECT_EQ(intersection2->color, Color::BLACK);
+
+  // Point at (25, 5, 0) should be on a white square again
+  Ray ray3(Vector3D(25, 5, -5), Vector3D(0, 0, 1));
+  auto intersection3 = plane.intersect(ray3);
+  ASSERT_TRUE(intersection3.has_value());
+  EXPECT_EQ(intersection3->color, Color::WHITE);
+}
+
+// Test setAlternateColor and getAlternateColor
+TEST(ChessboardPlaneTest, SetGetAlternateColor) {
+  ChessboardPlane plane('Y', 0, Color::RED, Color::BLUE);
+  EXPECT_EQ(plane.getAlternateColor(), Color::BLUE);
+
+  plane.setAlternateColor(Color::GREEN);
+  EXPECT_EQ(plane.getAlternateColor(), Color::GREEN);
+}
+
+// Test setCheckSize and getCheckSize
+TEST(ChessboardPlaneTest, SetGetCheckSize) {
+  ChessboardPlane plane('X', 0, Color::RED, Color::BLUE, 5.0);
+  EXPECT_DOUBLE_EQ(plane.getCheckSize(), 5.0);
+
+  plane.setCheckSize(15.0);
+  EXPECT_DOUBLE_EQ(plane.getCheckSize(), 15.0);
+
+  // Test invalid size
+  EXPECT_THROW(plane.setCheckSize(0.0), std::invalid_argument);
+  EXPECT_THROW(plane.setCheckSize(-5.0), std::invalid_argument);
+}
+
+// Test clone method
+TEST(ChessboardPlaneTest, Clone) {
+  double position = -5.5;
+  Color color = Color::CYAN;
+  Color altColor = Color::MAGENTA;
+  double checkSize = 7.5;
+  Transform transform;
+  transform.translate(1, 2, 3);
+  transform.rotateZ(30);
+
+  ChessboardPlane original('X', position, color, altColor, checkSize);
+  original.setTransform(transform);
+
+  std::shared_ptr<IPrimitive> cloneBase = original.clone();
+  ASSERT_NE(cloneBase, nullptr);
+
+  // Check if it's actually a ChessboardPlane
+  std::shared_ptr<ChessboardPlane> clone =
+      std::dynamic_pointer_cast<ChessboardPlane>(cloneBase);
+  ASSERT_NE(clone, nullptr);
+
+  // Check if properties are copied
+  EXPECT_EQ(clone->getColor(), color);
+  EXPECT_EQ(clone->getAlternateColor(), altColor);
+  EXPECT_DOUBLE_EQ(clone->getCheckSize(), checkSize);
+
+  // Compare matrices for transform equality
+  EXPECT_EQ(clone->getTransform().getMatrix(), transform.getMatrix());
+}

--- a/tests/test_SceneParser.cpp
+++ b/tests/test_SceneParser.cpp
@@ -9,6 +9,7 @@
 #include <libconfig.h++>
 #include "../src/core/Color.hpp"
 #include "../src/scene/parser/SceneParser.hpp"
+#include "../src/scene/primitives/ChessboardPlane.hpp"
 
 using namespace RayTracer;
 using namespace libconfig;
@@ -126,6 +127,50 @@ TEST(SceneParserTest, ParseOnePlane) {
   } catch (const std::exception& e) {
     std::cerr << "[WARNING] Error loading config: " << e.what() << "\n";
     FAIL() << "Exception thrown during plane parsing: " << e.what();
+  }
+}
+
+TEST(SceneParserTest, ParseOneChessboardPlane) {
+  Config cfg;
+  const char* cfgText = R"(
+  chessboardPlanes = (
+    {
+      axis = "Z";
+      position = -20;
+      color = { r = 64; g = 64; b = 255; };
+      checkerboard = {
+        alternateColor = { r = 200; g = 200; b = 200; };
+        size = 15.0;
+      }
+    }
+  );
+  )";
+
+  try {
+    cfg.readString(cfgText);
+    const Setting& planeSetting = cfg.lookup("chessboardPlanes")[0];
+
+    SceneParser parser;
+    ChessboardPlane result = parser.parseChessboardPlane(planeSetting);
+
+    EXPECT_EQ(result.getAxis(), Axis::Z);
+    EXPECT_FLOAT_EQ(result.getPosition(), -20);
+    EXPECT_TRUE(result.getColor().isEqual(Color(static_cast<uint8_t>(64),
+                                                static_cast<uint8_t>(64),
+                                                static_cast<uint8_t>(255))));
+    EXPECT_TRUE(result.getAlternateColor().isEqual(Color(static_cast<uint8_t>(200),
+                                                         static_cast<uint8_t>(200),
+                                                         static_cast<uint8_t>(200))));
+    EXPECT_DOUBLE_EQ(result.getCheckSize(), 15.0);
+
+    std::cout << "Chessboard plane parsed successfully!\n";
+
+  } catch (const SettingTypeException& e) {
+    std::cerr << "[WARNING] Error loading config: " << e.what() << "\n";
+    FAIL() << "Setting type error during chessboard plane parsing: " << e.what();
+  } catch (const std::exception& e) {
+    std::cerr << "[WARNING] Error loading config: " << e.what() << "\n";
+    FAIL() << "Exception thrown during chessboard plane parsing: " << e.what();
   }
 }
 


### PR DESCRIPTION
This pull request introduces a new `ChessboardPlane` primitive to the raytracer, which represents a plane with a chessboard pattern. The changes include adding the `ChessboardPlane` class, updating the scene parser to support the new primitive, modifying the existing `Plane` class to remove chessboard-related logic, and adding unit tests for the new functionality.

### New Feature: ChessboardPlane Primitive
* Added `ChessboardPlane` class in `src/scene/primitives/ChessboardPlane.{hpp,cpp}` to represent a plane with a checkerboard pattern. This includes methods for intersection, cloning, and managing checkerboard-specific properties like alternate color and square size. [[1]](diffhunk://#diff-a58b9be7fa6e2e90d2e93197ad49744f10e75172fa544277f1381f8fcd065042R1-R90) [[2]](diffhunk://#diff-73aae2b8108247b5445e9eebb8566ef85640c92e4f60a0801b112172787573f7R1-R101)

### Scene Parser Updates
* Updated `SceneParser` to parse `chessboardPlanes` from configuration files, including new methods `parseChessboardPlane` and `parseChessboardPlanes` in `SceneParser.{hpp,cpp}`. [[1]](diffhunk://#diff-a9d2aac98d50d2b3644a4de4f56eb2ed56d4bd110ff8b2be71d43f5c96a5e85aR39-R40) [[2]](diffhunk://#diff-2c1ab10b609c504bb45283e2df336ade523720b930ebd64c752b5e3a08e247afL157-R229) [[3]](diffhunk://#diff-2c1ab10b609c504bb45283e2df336ade523720b930ebd64c752b5e3a08e247afR416-R417)
* Added `ChessboardPlane` to the list of included primitives in `SceneParser`. [[1]](diffhunk://#diff-2c1ab10b609c504bb45283e2df336ade523720b930ebd64c752b5e3a08e247afR13) [[2]](diffhunk://#diff-a9d2aac98d50d2b3644a4de4f56eb2ed56d4bd110ff8b2be71d43f5c96a5e85aR18-R30)

### Modifications to Plane Class
* Simplified the `Plane` class by removing checkerboard-specific logic, such as alternate color and square size, as these are now handled by `ChessboardPlane`. [[1]](diffhunk://#diff-8ec16250329587e176b6516d5c68c3db87bb7c8f0aa9895f81bdb7d23e163d58L15-R18) [[2]](diffhunk://#diff-8ec16250329587e176b6516d5c68c3db87bb7c8f0aa9895f81bdb7d23e163d58L79-L85) [[3]](diffhunk://#diff-f9bed98521ea28ba9a28073adafe1c0ea8958e611df2ed52b5ecdbdbc584f329L116-L145)

### Configuration and Tests
* Added configuration support for `chessboardPlanes` in `scenes/demo_chessboard.cfg`.
* Added unit tests for `ChessboardPlane` in `tests/test_ChessboardPlane.cpp` and updated `CMakeLists.txt` to include the new test file. [[1]](diffhunk://#diff-7ecc858d8a9c1e2632d2fe1133a3e491a8cd8a5ea64a1ed24732aeb28b857057R1-R117) [[2]](diffhunk://#diff-4461c617ceae0c7e0206622aacdf555aedd62eb129c2efb74c84fa1567bcbe0dR3)
* Updated `test_SceneParser.cpp` to include tests for parsing `ChessboardPlane`.