### PR TITLE
fix: ensure generated documentation is cleaned up during fclean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,14 @@ check_normalize:
 doc:
 	@echo "Generating documentation..."
 	@doxygen Doxyfile
-	@open docs/html/index.html
+	@# Cross-platform open command - uses appropriate opener by OS
+	@if [ "$(shell uname)" = "Darwin" ]; then \
+		open docs/html/index.html; \
+	elif [ "$(shell uname)" = "Linux" ]; then \
+		xdg-open docs/html/index.html 2>/dev/null || \
+		echo "Documentation generated at: docs/html/index.html"; \
+	else \
+		echo "Documentation generated at: docs/html/index.html"; \
+	fi
 
 .PHONY: all re tests_run clean fclean normalize check_normalize cov doc

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,8 @@ fclean: clean
 	@echo "Cleaning up build directory..."
 	@rm -rf $(BUILD_DIR)
 	@rm -f $(TARGET)
+	@echo "Cleaning up generated documentation..."
+	@rm -rf docs/html
 
 normalize:
 	@echo "Applying clang format to all C++ files..."

--- a/docs/user_guide.dox
+++ b/docs/user_guide.dox
@@ -57,6 +57,10 @@
  * ✅ Supported Primitives:
  * - Sphere
  * - Plane
+ * - Cone (infinite and limited)
+ * - Cylinder (infinite and limited) 
+ * - Torus
+ * - Triangle
  *
  * ✅ Transformations:
  * - Translation
@@ -84,15 +88,90 @@
  * ## ⚙️ Compilation
  *
  * ### Makefile
- * - Required targets: `all`, `clean`, `fclean`, `re`
+ * The project provides a comprehensive Makefile with several useful targets:
+ * 
+ * ```bash
+ * make          # Compiles the project and creates the raytracer executable
+ * make clean    # Removes object files
+ * make fclean   # Removes all compiled files, build directory, and documentation
+ * make re       # Completely rebuilds the project (fclean + all)
+ * make normalize # Applies clang-format to all C++ files
+ * make check_normalize # Checks if code follows clang-format style without modifying
+ * make tests_run # Compiles and runs unit tests
+ * make cov      # Generates code coverage report (requires lcov)
+ * make doc      # Generates documentation using Doxygen and opens it
+ * ```
  *
  * ### CMake (optional):
+ * If you prefer using CMake directly:
  * ```bash
  * mkdir build && cd build
  * cmake .. -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release
  * cmake --build .
  * ```
+ * 
+ * #### CMake Build Options:
+ * - `-DBUILD_TESTS=ON` - Enable building test suite
+ * - `-DBUILD_PLUGINS=ON` - Enable building plugin modules
+ * - `-DCMAKE_BUILD_TYPE=Debug|Release` - Set build configuration
  *
+ * ---
+ *
+ * ## 🧠 Extending the Raytracer
+ * 
+ * ### 🔶 Adding a New Primitive
+ * 
+ * To add a new primitive to the raytracer, follow these steps:
+ * 
+ * 1. **Create the Primitive Class**:
+ *    - Implement a class that inherits from `IPrimitive` (or an appropriate interface like `ICylinder` if it's a variant)
+ *    - Required methods to implement:
+ *      - `intersect()` - Calculate ray intersection with your primitive
+ *      - `getNormalAt()` - Calculate surface normal at a point
+ *      - `setTransform()`, `getTransform()` - Handle transformations
+ *      - `setColor()`, `getColor()` - Handle color properties
+ *      - `clone()` - Create a copy of the primitive
+ * 
+ * 2. **Update the Factory**:
+ *    - In `PrimitiveFactory.cpp`, add a creation method for your primitive:
+ *      ```cpp
+ *      std::shared_ptr<YourPrimitive> PrimitiveFactory::createYourPrimitive(
+ *          const Setting& setting) {
+ *          // Parse configuration and create your primitive
+ *      }
+ *      ```
+ *    - Add the appropriate entry to the `primitiveCreators` map in the same file
+ * 
+ * 3. **Add the declaration in PrimitiveFactory.hpp**:
+ *    - Declare your creation method
+ *    - Include your primitive's header file
+ * 
+ * 4. **Example Usage in Configuration**:
+ *    ```cfg
+ *    primitives:
+ *    {
+ *      yourprimitives = (
+ *        {
+ *          // Your primitive's parameters
+ *          param1 = value1;
+ *          color = { r = 255; g = 0; b = 0; };
+ *          transform = {
+ *            translate = { x = 0; y = 0; z = 0; };
+ *            rotate = { x = 0; y = 0; z = 0; };
+ *            scale = { x = 1; y = 1; z = 1; };
+ *          };
+ *        }
+ *      );
+ *    }
+ *    ```
+ * 
+ * Note that the factory supports multiple formats for primitive parameters:
+ * - Direct coordinates: `x = 0; y = 10; z = 5;`
+ * - Grouped coordinates: `position = { x = 0; y = 10; z = 5; };`
+ * - Both integer and float values
+ * 
+ * The system also automatically applies transformations if a `transform` block is present.
+ * 
  * ---
  *
  * ## 🔌 Extensions and Plugins (bonus)

--- a/docs/user_guide.dox
+++ b/docs/user_guide.dox
@@ -41,6 +41,89 @@
  *   fieldOfView = 72.0;
  * }
  * ```
+ * 
+ * ### 📂 Scene Configuration Structure
+ * 
+ * Scene files use the libconfig++ format and are organized into three main sections:
+ * 
+ * #### 1. Camera Configuration
+ * ```cfg
+ * camera: {
+ *   resolution = { width = 1920; height = 1080; };
+ *   position = { x = 0; y = -100; z = 20; };
+ *   rotation = { x = 0; y = 0; z = 0; };
+ *   fieldOfView = 72.0;
+ * };
+ * ```
+ * 
+ * #### 2. Primitives Configuration
+ * Primitives are organized by type in array format:
+ * ```cfg
+ * primitives: {
+ *   # Spheres with position, radius and color
+ *   spheres = (
+ *     { x = 60; y = 5; z = 40; r = 25; color = { r = 255; g = 64; b = 64; }; },
+ *     { x = -40; y = 20; z = -10; r = 35; color = { r = 64; g = 255; b = 64; }; }
+ *   );
+ *   
+ *   # Planes with axis, position and color
+ *   planes = (
+ *     { axis = "Z"; position = -20; color = { r = 64; g = 64; b = 255; }; }
+ *   );
+ *   
+ *   # Cylinders with radius and color
+ *   cylinders = (
+ *     { 
+ *       radius = 5;
+ *       color = { r = 0; g = 255; b = 255; };
+ *       transform = {
+ *         translate = { x = 10; y = 0; z = 0; };
+ *         rotate = { x = 0; y = 0; z = 90; };
+ *       };
+ *     }
+ *   );
+ * };
+ * ```
+ * 
+ * #### 3. Lighting Configuration
+ * ```cfg
+ * lights: {
+ *   ambient = 0.3;
+ *   diffuse = 0.7;
+ *   
+ *   # Point lights with position and color
+ *   point = (
+ *     { x = 200; y = 50; z = 0; color = { r = 255; g = 255; b = 255; }; }
+ *   );
+ *   
+ *   # Directional lights with direction and color
+ *   directional = (
+ *     { direction = { x = -1; y = -1; z = -1; }; color = { r = 255; g = 255; b = 255; }; }
+ *   );
+ * };
+ * ```
+ * 
+ * ### 📝 Example Scenes
+ * 
+ * The project includes several example scenes in the `scenes/` directory that you can use as templates:
+ * 
+ * - `scenes/basic_scene.cfg` - A simple scene with a few spheres and a plane
+ * - `scenes/complex_scene.cfg` - A more complex scene with multiple primitive types
+ * - `scenes/demo_sphere.cfg` - Showcase of spheres with various transformations
+ * - `scenes/demo_cylinder.cfg` - Demonstration of cylinder primitives
+ * 
+ * To run an example scene:
+ * ```bash
+ * ./raytracer scenes/basic_scene.cfg
+ * ```
+ * 
+ * ### 🛠️ Configuration Tips
+ * 
+ * - All primitive attributes support both integer and float values
+ * - Colors are defined with RGB values from 0-255
+ * - Comments can be added with `#` or `//`
+ * - Transformation blocks can be added to any primitive for positioning
+ * - The order of sections (camera, primitives, lights) is not important
  *
  * ---
  *

--- a/src/core/Color.cpp
+++ b/src/core/Color.cpp
@@ -9,7 +9,7 @@
  * @file Color.cpp
  * @brief Implementation of the Color class for RGB color representation and
  * operations
- * @author Santi
+ * @author @paul-antoine
  * @date 2025-05-16
  * @version 1.0
  */

--- a/src/core/Color.hpp
+++ b/src/core/Color.hpp
@@ -9,7 +9,7 @@
  * @file Color.hpp
  * @brief Provides the Color class for managing RGB color values with various
  * operations and transformations
- * @author Santi
+ * @author @paul-antoine
  * @date 2025-05-16
  * @version 1.0
  */

--- a/src/core/Matrix.cpp
+++ b/src/core/Matrix.cpp
@@ -8,7 +8,7 @@
 /**
  * @file Matrix.cpp
  * @brief Implementation of the 4x4 matrix class for 3D transformations
- * @author Santi
+ * @author @paul-antoine
  * @date 2025-05-16
  * @version 1.0
  */

--- a/src/core/Matrix.hpp
+++ b/src/core/Matrix.hpp
@@ -8,7 +8,7 @@
 /**
  * @file Matrix.hpp
  * @brief Definition of the Matrix class for 3D mathematical transformations
- * @author Santi
+ * @author @paul-antoine
  * @date 2025-05-16
  * @version 1.0
  */

--- a/src/core/Ray.cpp
+++ b/src/core/Ray.cpp
@@ -9,7 +9,7 @@
  * @file Ray.cpp
  * @brief Implementation of the Ray class which represents a ray with origin and
  * direction for ray tracing
- * @author Santi
+ * @author @paul-antoine
  * @date 2025-05-16
  * @version 1.0
  */

--- a/src/core/Ray.hpp
+++ b/src/core/Ray.hpp
@@ -9,7 +9,7 @@
  * @file Ray.hpp
  * @brief Provides the Ray class for representing rays with origin points and
  * direction vectors for ray tracing
- * @author Santi
+ * @author @paul-antoine
  * @date 2025-05-16
  * @version 1.0
  */

--- a/src/core/RenderTile.cpp
+++ b/src/core/RenderTile.cpp
@@ -9,7 +9,7 @@
  * @file RenderTile.cpp
  * @brief Implementation of the tile-based rendering system for parallel
  * processing
- * @author Santi
+ * @author @paul-antoine
  * @date 2025-05-16
  * @version 1.0
  */

--- a/src/core/RenderTile.hpp
+++ b/src/core/RenderTile.hpp
@@ -9,7 +9,7 @@
  * @file RenderTile.hpp
  * @brief Defines the RenderTile class for dividing the image into smaller
  * chunks for parallel rendering
- * @author Santi
+ * @author @paul-antoine
  * @date 2025-05-16
  * @version 1.0
  */

--- a/src/core/ThreadPool.cpp
+++ b/src/core/ThreadPool.cpp
@@ -9,7 +9,7 @@
  * @file ThreadPool.cpp
  * @brief Implementation of a thread pool for parallel task execution to
  * optimize rendering performance
- * @author Santi
+ * @author @paul-antoine
  * @date 2025-05-16
  * @version 1.0
  */

--- a/src/core/ThreadPool.hpp
+++ b/src/core/ThreadPool.hpp
@@ -9,7 +9,7 @@
  * @file ThreadPool.hpp
  * @brief Provides a thread pool implementation for parallel task execution in
  * the ray tracer
- * @author Santi
+ * @author @paul-antoine
  * @date 2025-05-16
  * @version 1.0
  */

--- a/src/core/Transform.cpp
+++ b/src/core/Transform.cpp
@@ -9,7 +9,7 @@
  * @file Transform.cpp
  * @brief Implementation of the transformation matrix class for 3D affine
  * transformations
- * @author Santi
+ * @author @paul-antoine
  * @date 2025-05-16
  * @version 1.0
  */

--- a/src/core/Transform.hpp
+++ b/src/core/Transform.hpp
@@ -9,7 +9,7 @@
  * @file Transform.hpp
  * @brief Provides the Transform class for representing and applying 3D
  * transformations like translation, rotation, and scaling
- * @author Santi
+ * @author @paul-antoine
  * @date 2025-05-16
  * @version 1.0
  */

--- a/src/core/Vector3D.cpp
+++ b/src/core/Vector3D.cpp
@@ -9,7 +9,7 @@
  * @file Vector3D.cpp
  * @brief Implementation of the 3D vector class with mathematical operations for
  * 3D graphics
- * @author Santi
+ * @author @paul-antoine
  * @date 2025-05-16
  * @version 1.0
  */

--- a/src/core/Vector3D.hpp
+++ b/src/core/Vector3D.hpp
@@ -9,7 +9,7 @@
  * @file Vector3D.hpp
  * @brief Definition of the Vector3D class for representing and manipulating 3D
  * vectors in space
- * @author Santi
+ * @author @paul-antoine
  * @date 2025-05-16
  * @version 1.0
  */

--- a/src/display/PPMDisplay.cpp
+++ b/src/display/PPMDisplay.cpp
@@ -9,7 +9,7 @@
  * @file PPMDisplay.cpp
  * @brief Implementation of the PPM display system for rendering and saving
  * images in the PPM format
- * @author Santi
+ * @author @paul-antoine
  * @date 2025-05-16
  * @version 1.0
  */

--- a/src/display/PPMDisplay.hpp
+++ b/src/display/PPMDisplay.hpp
@@ -9,7 +9,7 @@
  * @file PPMDisplay.hpp
  * @brief Defines the PPMDisplay class which handles rendering to PPM image
  * format
- * @author Santi
+ * @author @paul-antoine
  * @date 2025-05-16
  * @version 1.0
  */

--- a/src/display/SFMLDisplay.cpp
+++ b/src/display/SFMLDisplay.cpp
@@ -9,7 +9,7 @@
  * @file SFMLDisplay.cpp
  * @brief Implementation of the display system using SFML for real-time
  * rendering visualization
- * @author Santi
+ * @author @paul-antoine
  * @date 2025-05-16
  * @version 1.0
  */

--- a/src/display/SFMLDisplay.hpp
+++ b/src/display/SFMLDisplay.hpp
@@ -9,7 +9,7 @@
  * @file SFMLDisplay.hpp
  * @brief Defines the SFMLDisplay class which handles real-time rendering using
  * the SFML library
- * @author Santi
+ * @author @paul-antoine
  * @date 2025-05-16
  * @version 1.0
  */

--- a/src/exceptions/RaytracerException.cpp
+++ b/src/exceptions/RaytracerException.cpp
@@ -9,7 +9,7 @@
  * @file RaytracerException.cpp
  * @brief Implementation of the base exception class used throughout the
  * raytracer
- * @author Santi
+ * @author @santiago
  * @date 2025-05-16
  * @version 1.0
  */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,7 +9,7 @@
  * @file main.cpp
  * @brief Main entry point for the Raytracer application, handling command-line
  * arguments, scene loading, and rendering
- * @author Santi
+ * @author @paul-antoine @santiago @mael
  * @date 2025-05-16
  * @version 1.0
  */

--- a/src/scene/Camera.cpp
+++ b/src/scene/Camera.cpp
@@ -9,7 +9,7 @@
  * @file Camera.cpp
  * @brief Implementation of the Camera class which handles view position,
  * orientation and ray generation
- * @author Santi
+ * @author @paul-antoine
  * @date 2025-05-16
  * @version 1.0
  */

--- a/src/scene/Camera.hpp
+++ b/src/scene/Camera.hpp
@@ -8,7 +8,7 @@
 /**
  * @file Camera.hpp
  * @brief Defines the Camera class for scene viewing and ray generation
- * @author Santi
+ * @author @paul-antoine
  * @date 2025-05-16
  * @version 1.0
  */

--- a/src/scene/Resolution.cpp
+++ b/src/scene/Resolution.cpp
@@ -8,7 +8,7 @@
 /**
  * @file Resolution.cpp
  * @brief Implementation of the Resolution class which handles image dimensions
- * @author Santi
+ * @author @santiago
  * @date 2025-05-16
  * @version 1.0
  */

--- a/src/scene/Resolution.hpp
+++ b/src/scene/Resolution.hpp
@@ -9,7 +9,7 @@
  * @file Resolution.hpp
  * @brief Defines the Resolution class for managing image dimensions in the ray
  * tracer
- * @author Santi
+ * @author @santiago
  * @date 2025-05-16
  * @version 1.0
  */

--- a/src/scene/Scene.cpp
+++ b/src/scene/Scene.cpp
@@ -9,7 +9,7 @@
  * @file Scene.cpp
  * @brief Implementation of the Scene class that manages all 3D objects, lights
  * and rendering environment
- * @author Santi
+ * @author @paul-antoine
  * @date 2025-05-16
  * @version 1.0
  */

--- a/src/scene/Scene.hpp
+++ b/src/scene/Scene.hpp
@@ -9,7 +9,7 @@
  * @file Scene.hpp
  * @brief Definition of the Scene class for representing and managing the entire
  * 3D scene
- * @author Santi
+ * @author @paul-antoine
  * @date 2025-05-16
  * @version 1.0
  */

--- a/src/scene/SceneBuilder.cpp
+++ b/src/scene/SceneBuilder.cpp
@@ -9,7 +9,7 @@
  * @file SceneBuilder.cpp
  * @brief Implementation of the builder pattern for constructing Scene objects
  * with a fluent interface
- * @author Santi
+ * @author @paul-antoine
  * @date 2025-05-16
  * @version 1.0
  */

--- a/src/scene/SceneBuilder.hpp
+++ b/src/scene/SceneBuilder.hpp
@@ -9,7 +9,7 @@
  * @file SceneBuilder.hpp
  * @brief Defines the SceneBuilder class which implements the Builder pattern
  * for creating Scene objects
- * @author Santi
+ * @author @paul-antoine
  * @date 2025-05-16
  * @version 1.0
  */

--- a/src/scene/lights/AmbientLight.cpp
+++ b/src/scene/lights/AmbientLight.cpp
@@ -9,7 +9,7 @@
  * @file AmbientLight.cpp
  * @brief Implementation of the ambient light class which provides constant,
  * non-directional illumination
- * @author Santi
+ * @author @santiago
  * @date 2025-05-16
  * @version 1.0
  */

--- a/src/scene/lights/AmbientLight.hpp
+++ b/src/scene/lights/AmbientLight.hpp
@@ -9,7 +9,7 @@
  * @file AmbientLight.hpp
  * @brief Definition of the AmbientLight class for representing ambient lighting
  * in the scene
- * @author Santi
+ * @author @santiago
  * @date 2025-05-16
  * @version 1.0
  */

--- a/src/scene/lights/DirectionalLight.cpp
+++ b/src/scene/lights/DirectionalLight.cpp
@@ -9,7 +9,7 @@
  * @file DirectionalLight.cpp
  * @brief Implementation of the directional light class which simulates light
  * coming from infinity in a specific direction
- * @author Santi
+ * @author @santiago
  * @date 2025-05-16
  * @version 1.0
  */

--- a/src/scene/lights/DirectionalLight.hpp
+++ b/src/scene/lights/DirectionalLight.hpp
@@ -9,7 +9,7 @@
  * @file DirectionalLight.hpp
  * @brief Definition of the DirectionalLight class for representing directional
  * light sources
- * @author Santi
+ * @author @santiago
  * @date 2025-05-16
  * @version 1.0
  */

--- a/src/scene/lights/Light.hpp
+++ b/src/scene/lights/Light.hpp
@@ -9,7 +9,7 @@
  * @file Light.hpp
  * @brief Defines the abstract Light base class for all light sources in the ray
  * tracer
- * @author Santi
+ * @author @santiago
  * @date 2025-05-16
  * @version 1.0
  */

--- a/src/scene/lights/LightFactory.cpp
+++ b/src/scene/lights/LightFactory.cpp
@@ -9,7 +9,7 @@
  * @file LightFactory.cpp
  * @brief Implementation of the factory class for creating different types of
  * light sources
- * @author Santi
+ * @author @santiago
  * @date 2025-05-16
  * @version 1.0
  */

--- a/src/scene/lights/LightFactory.hpp
+++ b/src/scene/lights/LightFactory.hpp
@@ -8,7 +8,7 @@
 /**
  * @file LightFactory.hpp
  * @brief Provides a factory class for creating different types of light sources
- * @author Santi
+ * @author @santiago
  * @date 2025-05-16
  * @version 1.0
  */

--- a/src/scene/lights/LightingSettings.hpp
+++ b/src/scene/lights/LightingSettings.hpp
@@ -9,7 +9,7 @@
  * @file LightingSettings.hpp
  * @brief Defines the LightingSettings structure for storing global lighting
  * parameters
- * @author Santi
+ * @author @santiago
  * @date 2025-05-16
  * @version 1.0
  */

--- a/src/scene/lights/PointLight.cpp
+++ b/src/scene/lights/PointLight.cpp
@@ -9,7 +9,7 @@
  * @file PointLight.cpp
  * @brief Implementation of the point light class which simulates light
  * emanating from a specific position in 3D space
- * @author Santi
+ * @author @santiago
  * @date 2025-05-16
  * @version 1.0
  */

--- a/src/scene/lights/PointLight.hpp
+++ b/src/scene/lights/PointLight.hpp
@@ -9,7 +9,7 @@
  * @file PointLight.hpp
  * @brief Definition of the PointLight class for representing punctual light
  * sources
- * @author Santi
+ * @author @santiago
  * @date 2025-05-16
  * @version 1.0
  */

--- a/src/scene/parser/SceneParser.cpp
+++ b/src/scene/parser/SceneParser.cpp
@@ -9,7 +9,7 @@
  * @file SceneParser.cpp
  * @brief Implementation of the configuration file parser for loading 3D scenes
  * from cfg files
- * @author Santi
+ * @author @santiago
  * @date 2025-05-16
  * @version 1.0
  */

--- a/src/scene/parser/SceneParser.hpp
+++ b/src/scene/parser/SceneParser.hpp
@@ -9,7 +9,7 @@
  * @file SceneParser.hpp
  * @brief Definition of the SceneParser class for parsing scene configuration
  * files
- * @author Santi
+ * @author @santiago
  * @date 2025-05-16
  * @version 1.0
  */

--- a/src/scene/primitives/Cone.cpp
+++ b/src/scene/primitives/Cone.cpp
@@ -9,7 +9,7 @@
  * @file Cone.cpp
  * @brief Implementation of the infinite cone primitive with ray-cone
  * intersection algorithms
- * @author Santi
+ * @author @mael
  * @date 2025-05-16
  * @version 1.0
  */

--- a/src/scene/primitives/Cone.hpp
+++ b/src/scene/primitives/Cone.hpp
@@ -9,7 +9,7 @@
  * @file Cone.hpp
  * @brief Definition of the Cone class for representing infinite cones in the
  * raytracing engine
- * @author Santi
+ * @author @mael
  * @date 2025-05-16
  * @version 1.0
  */

--- a/src/scene/primitives/Cylinder.cpp
+++ b/src/scene/primitives/Cylinder.cpp
@@ -9,7 +9,7 @@
  * @file Cylinder.cpp
  * @brief Implementation of the Cylinder class which provides cylindrical
  * primitive functionality for ray tracing
- * @author Santi
+ * @author @mael
  * @date 2025-05-16
  * @version 1.0
  */

--- a/src/scene/primitives/Cylinder.hpp
+++ b/src/scene/primitives/Cylinder.hpp
@@ -9,7 +9,7 @@
  * @file Cylinder.hpp
  * @brief Definition of the Cylinder class for representing cylinders in the
  * raytracing engine
- * @author Santi
+ * @author @mael
  * @date 2025-05-16
  * @version 1.0
  */

--- a/src/scene/primitives/ICone.hpp
+++ b/src/scene/primitives/ICone.hpp
@@ -9,7 +9,7 @@
  * @file ICone.hpp
  * @brief Definition of the ICone interface for cone primitives in the
  * raytracing engine
- * @author Santi
+ * @author @mael
  * @date 2025-05-16
  * @version 1.0
  */

--- a/src/scene/primitives/ICylinder.hpp
+++ b/src/scene/primitives/ICylinder.hpp
@@ -5,6 +5,14 @@
 ** ICylinder
 */
 
+/**
+ * @file ICylinder.hpp
+ * @brief Interface for cylinder primitives in the raytracing engine
+ * @author @mael
+ * @date 2025-05-16
+ * @version 1.0
+ */
+
 #ifndef ICYLINDER_HPP_
 #define ICYLINDER_HPP_
 

--- a/src/scene/primitives/LimitedCone.cpp
+++ b/src/scene/primitives/LimitedCone.cpp
@@ -9,7 +9,7 @@
  * @file LimitedCone.cpp
  * @brief Implementation of a cone primitive with height constraints and
  * optional cap for ray tracing
- * @author Santi
+ * @author @mael
  * @date 2025-05-16
  * @version 1.0
  */

--- a/src/scene/primitives/LimitedCone.hpp
+++ b/src/scene/primitives/LimitedCone.hpp
@@ -9,7 +9,7 @@
  * @file LimitedCone.hpp
  * @brief Definition of the LimitedCone class for representing cones with a
  * limited height
- * @author Santi
+ * @author @mael
  * @date 2025-05-16
  * @version 1.0
  */

--- a/src/scene/primitives/LimitedCylinder.cpp
+++ b/src/scene/primitives/LimitedCylinder.cpp
@@ -5,6 +5,15 @@
 ** LimitedCylinder
 */
 
+/**
+ * @file LimitedCylinder.cpp
+ * @brief Implementation of the LimitedCylinder class which provides limited
+ * cylinder primitive functionality for ray tracing
+ * @author @mael
+ * @date 2025-05-16
+ * @version 1.0
+ */
+
 #include "LimitedCylinder.hpp"
 #include <cmath>
 #include <limits>

--- a/src/scene/primitives/LimitedCylinder.hpp
+++ b/src/scene/primitives/LimitedCylinder.hpp
@@ -5,6 +5,15 @@
 ** Cylinder primitive class header
 */
 
+/**
+ * @file LimitedCylinder.hpp
+ * @brief Header file for the LimitedCylinder class which provides limited
+ * cylinder primitive functionality for ray tracing
+ * @author @mael
+ * @date 2025-05-16
+ * @version 1.0
+ */
+
 #ifndef LIMITEDCYLINDER_HPP_
 #define LIMITEDCYLINDER_HPP_
 

--- a/src/scene/primitives/Plane.cpp
+++ b/src/scene/primitives/Plane.cpp
@@ -8,7 +8,7 @@
 /**
  * @file Plane.cpp
  * @brief Implementation of the infinite plane primitive
- * @author Santi
+ * @author @mael
  * @date 2025-05-16
  * @version 1.0
  */

--- a/src/scene/primitives/Plane.hpp
+++ b/src/scene/primitives/Plane.hpp
@@ -9,7 +9,7 @@
  * @file Plane.hpp
  * @brief Definition of the Plane class for representing infinite planes in the
  * raytracing engine
- * @author Santi
+ * @author @mael
  * @date 2025-05-16
  * @version 1.0
  */

--- a/src/scene/primitives/PrimitiveFactory.cpp
+++ b/src/scene/primitives/PrimitiveFactory.cpp
@@ -9,7 +9,7 @@
  * @file PrimitiveFactory.cpp
  * @brief Implementation of the factory class for creating different types of
  * primitives
- * @author Santi
+ * @author @paul-antoine
  * @date 2025-05-17
  * @version 1.0
  */

--- a/src/scene/primitives/PrimitiveFactory.hpp
+++ b/src/scene/primitives/PrimitiveFactory.hpp
@@ -9,7 +9,7 @@
  * @file PrimitiveFactory.hpp
  * @brief Provides a factory class for creating different types of primitive
  * objects
- * @author Santi
+ * @author @paul-antoine
  * @date 2025-05-17
  * @version 1.0
  */

--- a/src/scene/primitives/Sphere.cpp
+++ b/src/scene/primitives/Sphere.cpp
@@ -9,7 +9,7 @@
  * @file Sphere.cpp
  * @brief Implementation of the sphere primitive with ray-sphere intersection
  * calculation
- * @author Santi
+ * @author @paul-antoine
  * @date 2025-05-16
  * @version 1.0
  */

--- a/src/scene/primitives/Sphere.hpp
+++ b/src/scene/primitives/Sphere.hpp
@@ -9,7 +9,7 @@
  * @file Sphere.hpp
  * @brief Definition of the Sphere class for representing spheres in the
  * raytracing engine
- * @author Santi
+ * @author @paul-antoine
  * @date 2025-05-16
  * @version 1.0
  */

--- a/src/scene/primitives/Torus.cpp
+++ b/src/scene/primitives/Torus.cpp
@@ -5,6 +5,15 @@
 ** Torus
 */
 
+/**
+ * @file Torus.cpp
+ * @brief Implementation of the Torus class which provides toroidal primitive
+ * functionality for ray tracing
+ * @author @mael
+ * @date 2025-05-16
+ * @version 1.0
+ */
+
 #include "Torus.hpp"
 #include <cmath>
 #include <stdexcept>

--- a/src/scene/primitives/Torus.hpp
+++ b/src/scene/primitives/Torus.hpp
@@ -5,6 +5,15 @@
 ** Torus
 */
 
+/**
+ * @file Torus.cpp
+ * @brief Implementation of the Torus class which provides toroidal primitive
+ * functionality for ray tracing
+ * @author @mael
+ * @date 2025-05-16
+ * @version 1.0
+ */
+
 #ifndef TORUS_HPP_
 #define TORUS_HPP_
 

--- a/src/scene/primitives/Triangle.cpp
+++ b/src/scene/primitives/Triangle.cpp
@@ -5,6 +5,15 @@
 ** Triangle
 */
 
+/**
+ * @file Triangle.cpp
+ * @brief Implementation of the Triangle class for representing triangular
+ * primitives in the raytracing engine
+ * @author @paul-antoine
+ * @date 2025-05-16
+ * @version 1.0
+ */
+
 #include "Triangle.hpp"
 #include <cmath>
 #include <stdexcept>

--- a/src/scene/primitives/Triangle.cpp
+++ b/src/scene/primitives/Triangle.cpp
@@ -9,7 +9,7 @@
  * @file Triangle.cpp
  * @brief Implementation of the Triangle class for representing triangular
  * primitives in the raytracing engine
- * @author @paul-antoine
+ * @author @mael
  * @date 2025-05-16
  * @version 1.0
  */

--- a/src/scene/primitives/Triangle.hpp
+++ b/src/scene/primitives/Triangle.hpp
@@ -5,6 +5,15 @@
 ** Triangle
 */
 
+/**
+ * @file Triangle.cpp
+ * @brief Implementation of the Triangle class for representing triangular
+ * primitives in the raytracing engine
+ * @author @paul-antoine
+ * @date 2025-05-16
+ * @version 1.0
+ */
+
 #pragma once
 
 #include <memory>

--- a/src/scene/primitives/Triangle.hpp
+++ b/src/scene/primitives/Triangle.hpp
@@ -9,7 +9,7 @@
  * @file Triangle.cpp
  * @brief Implementation of the Triangle class for representing triangular
  * primitives in the raytracing engine
- * @author @paul-antoine
+ * @author @mael
  * @date 2025-05-16
  * @version 1.0
  */


### PR DESCRIPTION
This pull request updates the `Makefile` to include additional cleanup steps for generated documentation during the `fclean` target.

* **Enhancement to cleanup process:**
  * [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R42-R43): Added a command to remove the `docs/html` directory as part of the `fclean` target to ensure that generated documentation is also cleaned up.