### PR TITLE
fix: update fclean target to remove generated documentation directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ fclean: clean
 	@rm -rf $(BUILD_DIR)
 	@rm -f $(TARGET)
 	@echo "Cleaning up generated documentation..."
-	@rm -rf $(DOCS_OUT)
+	@rm -rf docs/html
 
 normalize:
 	@echo "Applying clang format to all C++ files..."


### PR DESCRIPTION
This pull request updates the `Makefile` to refine the cleanup process for generated documentation.

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L43-R43): Updated the `fclean: clean` target to specifically remove the `docs/html` directory instead of the variable `$(DOCS_OUT)`, ensuring a more targeted cleanup.